### PR TITLE
Throw error if `registerMethods` was never called

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -69,6 +69,7 @@ async function handleMessage(
     throw new Error("No handler registered for " + message.type);
   }
 
+  console.debug(`Messenger:`, message.type, message.args, "from", { sender });
   const response = await handler.call(sender, ...message.args).then(
     (value) => ({ value }),
     (error: unknown) => ({
@@ -78,6 +79,7 @@ async function handleMessage(
     })
   );
 
+  console.debug(`Messenger:`, message.type, "responds", response);
   return { ...response, __webext_messenger__ };
 }
 

--- a/index.ts
+++ b/index.ts
@@ -180,6 +180,7 @@ export function registerMethods(methods: Partial<MessengerMethods>): void {
       throw new Error(`Handler already set for ${type}`);
     }
 
+    console.debug(`Messenger: Registered`, type);
     handlers.set(type, method);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webext-messenger",
-  "version": "0.6.1",
+  "version": "0.7.0-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webext-messenger",
-      "version": "0.6.1",
+      "version": "0.7.0-0",
       "license": "MIT",
       "dependencies": {
         "serialize-error": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webext-messenger",
-  "version": "0.6.1",
+  "version": "0.7.0-0",
   "description": "Browser Extension component messaging framework",
   "keywords": [],
   "repository": "pixiebrix/extension-messaging",

--- a/test/demo-extension/background/registration.ts
+++ b/test/demo-extension/background/registration.ts
@@ -23,7 +23,7 @@ declare global {
 
 if (!isBackgroundPage()) {
   throw new Error(
-    "This file must only be run in the background page, which is the receiving eng"
+    "This file must only be run in the background page, which is the receiving end"
   );
 }
 

--- a/test/demo-extension/contentscript/fixtures/unrelatedMessageListener.ts
+++ b/test/demo-extension/contentscript/fixtures/unrelatedMessageListener.ts
@@ -1,0 +1,3 @@
+browser.runtime.onMessage.addListener((message: unknown) => {
+  console.log("I’m an unrelated message listener. I’ve seen", { message });
+});

--- a/test/demo-extension/contentscript/registration.ts
+++ b/test/demo-extension/contentscript/registration.ts
@@ -25,7 +25,7 @@ declare global {
 
 if (!isContentScript()) {
   throw new Error(
-    "This file must only be run in the content script, which is the receiving eng"
+    "This file must only be run in the content script, which is the receiving end"
   );
 }
 

--- a/test/demo-extension/manifest.json
+++ b/test/demo-extension/manifest.json
@@ -31,6 +31,14 @@
         "~node_modules/webextension-polyfill",
         "contentscript/registration.ts"
       ]
+    },
+    {
+      "all_frames": true,
+      "matches": ["https://text.npr.org//*"],
+      "js": [
+        "~node_modules/webextension-polyfill",
+        "contentscript/fixtures/unrelatedMessageListener.ts"
+      ]
     }
   ]
 }


### PR DESCRIPTION
- Fixes #13 
	- Every message and every response has a `__webext-messenger__: true` key, so `undefined` return values can't be confused with unhandled messages 
- Fixes #14 
	- "Handler registered"
	- "Message received"
	- "Message handled"