### PR TITLE
Partial attempt at removing polyfill dependency

### DIFF
--- a/.parcelrc
+++ b/.parcelrc
@@ -1,11 +1,6 @@
 {
 	"extends": "@parcel/config-webextension",
 	"transformers": {
-		"browser-polyfill.js": [],
 		"*.md": ["@parcel/transformer-raw"]
-	},
- 	// The following preserves `webextensions-polyfill`’s UMD package without re-bundling it
- 	"packagers": {
- 		"browser-polyfill.js": "@parcel/packager-raw"
- 	}
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,13 @@
         "serialize-error": "^8.1.0",
         "type-fest": "^2.3.4",
         "webext-detect-page": "^3.0.2",
-        "webextension-polyfill": "^0.8.0"
+        "webext-polyfill-kinda": "^0.1.1"
       },
       "devDependencies": {
         "@parcel/config-webextension": "^2.0.0-rc.0",
         "@sindresorhus/tsconfig": "^2.0.0",
         "@types/chrome": "^0.0.154",
-        "@types/firefox-webext-browser": "^82.0.1",
+        "@types/webextension-polyfill": "^0.8.0",
         "@typescript-eslint/eslint-plugin": "^4.30.0",
         "@typescript-eslint/parser": "^4.30.0",
         "eslint": "^7.32.0",
@@ -32,6 +32,7 @@
         "npm-run-all": "^4.1.5",
         "parcel": "^2.0.0-rc.0",
         "typescript": "^4.4.2",
+        "webextension-polyfill": "^0.8.0",
         "xo": "^0.44.0"
       }
     },
@@ -2282,12 +2283,6 @@
       "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==",
       "dev": true
     },
-    "node_modules/@types/firefox-webext-browser": {
-      "version": "82.0.1",
-      "resolved": "https://registry.npmjs.org/@types/firefox-webext-browser/-/firefox-webext-browser-82.0.1.tgz",
-      "integrity": "sha512-odcPKiJ34N8k53clIWen3hLvl09ja7SQ9NqtUbgmqeJ/a/ZRQiF665iXSFPcnl6cBn2XQgEg2lsUUApYNiyj+g==",
-      "dev": true
-    },
     "node_modules/@types/har-format": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.7.tgz",
@@ -2343,6 +2338,12 @@
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+    },
+    "node_modules/@types/webextension-polyfill": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@types/webextension-polyfill/-/webextension-polyfill-0.8.0.tgz",
+      "integrity": "sha512-usmQx2snpNkVl2VoOGZCdrPnfHL+CjuSFy84ZdTwQ2b2cvyygF/zGW5YI6Zywk+bfq9zmYpORO9lmdN7DknpRw==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "4.30.0",
@@ -8575,9 +8576,9 @@
       "dev": true
     },
     "node_modules/jest-worker": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.1.0.tgz",
-      "integrity": "sha512-mO4PHb2QWLn9yRXGp7rkvXLAYuxwhq1ZYUo0LoDhg8wqvv4QizP1ZWEJOeolgbEgAWZLIEU0wsku8J+lGWfBhg==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.0.tgz",
+      "integrity": "sha512-laB0ZVIBz+voh/QQy9dmUuuDsadixeerrKqyVpgPz+CCWiOYjOBabUXHIXZhsdvkWbLqSHbgkAHWl5cg24Q6RA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -9154,9 +9155,9 @@
       }
     },
     "node_modules/map-obj": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
-      "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -11401,9 +11402,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -13111,9 +13112,9 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.0.tgz",
-      "integrity": "sha512-FpR4Qe0Yt4knSQ5u2bA1wkM0R8VlVsvhyfSHvomXRivS4vPLk0dJV2IhRBIHRABh7AFutdMeElIA5y1dETwMBg==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.4.tgz",
+      "integrity": "sha512-E2CkNMN+1cho04YpdANyRrn8CyN4yMy+WdFKZIySFZrGXZxJwJP6PMNGGc/Mcr6qygQHUUqRxnAPmi0M9f00XA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -13866,10 +13867,16 @@
       "resolved": "https://registry.npmjs.org/webext-detect-page/-/webext-detect-page-3.0.2.tgz",
       "integrity": "sha512-CdU8W+6g05YAYrkdOfqUNrG9A4AybemgPGC+xeKnffRO4tbBrdYYy77qO0jlj7Udw9HXcE2xeFlEoW1ywjwTZw=="
     },
+    "node_modules/webext-polyfill-kinda": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/webext-polyfill-kinda/-/webext-polyfill-kinda-0.1.1.tgz",
+      "integrity": "sha512-t0b+b9PRDrZ1f7+bJtRbsACdMzJM34AFxCpyG/nRnyR9XRbNkqXZgo4mEDu3FIrd5/o7MDlxHj3UYS5t0ZoLdw=="
+    },
     "node_modules/webextension-polyfill": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.8.0.tgz",
-      "integrity": "sha512-a19+DzlT6Kp9/UI+mF9XQopeZ+n2ussjhxHJ4/pmIGge9ijCDz7Gn93mNnjpZAk95T4Tae8iHZ6sSf869txqiQ=="
+      "integrity": "sha512-a19+DzlT6Kp9/UI+mF9XQopeZ+n2ussjhxHJ4/pmIGge9ijCDz7Gn93mNnjpZAk95T4Tae8iHZ6sSf869txqiQ==",
+      "dev": true
     },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
@@ -13878,9 +13885,9 @@
       "dev": true
     },
     "node_modules/webpack": {
-      "version": "5.51.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.51.1.tgz",
-      "integrity": "sha512-xsn3lwqEKoFvqn4JQggPSRxE4dhsRcysWTqYABAZlmavcoTmwlOb9b1N36Inbt/eIispSkuHa80/FJkDTPos1A==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.53.0.tgz",
+      "integrity": "sha512-RZ1Z3z3ni44snoWjfWeHFyzvd9HMVYDYC5VXmlYUT6NWgEOWdCNpad5Fve2CzzHoRED7WtsKe+FCyP5Vk4pWiQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -13926,9 +13933,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.0.tgz",
-      "integrity": "sha512-fahN08Et7P9trej8xz/Z7eRu8ltyiygEo/hnRi9KqBUs80KeDcnf96ZJo++ewWd84fEf3xSX9bp4ZS9hbw0OBw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.1.tgz",
+      "integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -13936,9 +13943,9 @@
       }
     },
     "node_modules/webpack/node_modules/acorn": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-      "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+      "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -13959,9 +13966,9 @@
       }
     },
     "node_modules/webpack/node_modules/enhanced-resolve": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
-      "integrity": "sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
+      "integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -13996,9 +14003,9 @@
       }
     },
     "node_modules/webpack/node_modules/tapable": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
-      "integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -14251,14 +14258,14 @@
       }
     },
     "node_modules/xo/node_modules/@eslint/eslintrc": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.0.tgz",
-      "integrity": "sha512-FPnE4y+crrKBF0c9PckDHFuPDQl+wRX6S9jeSw2WwM2YNmrdRch3gx3DOTWpqpQu0G9yoJaeSSrJLiV/29tGyQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.1.tgz",
+      "integrity": "sha512-bkZOM1byYEdqFpWUzivekkhxD0diJ5NUQ7a2ReCP5+zvRu9T5R4t0cxVGqI1knerw3KzyuuMvGTHRihon0m3ng==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^8.0.0",
+        "espree": "^9.0.0",
         "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
@@ -14271,9 +14278,9 @@
       }
     },
     "node_modules/xo/node_modules/acorn": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-      "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+      "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -14304,12 +14311,12 @@
       }
     },
     "node_modules/xo/node_modules/espree": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-8.0.0.tgz",
-      "integrity": "sha512-y/+i23dwTjIDJrYCcjcAMr3c3UGbPIjC6THMQKjWmhP97fW0FPiI89kmpKfmgV/5jrkIi6toQP+CMm3qBE1Hig==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.0.0.tgz",
+      "integrity": "sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.4.1",
+        "acorn": "^8.5.0",
         "acorn-jsx": "^5.3.1",
         "eslint-visitor-keys": "^3.0.0"
       },
@@ -16142,12 +16149,6 @@
       "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==",
       "dev": true
     },
-    "@types/firefox-webext-browser": {
-      "version": "82.0.1",
-      "resolved": "https://registry.npmjs.org/@types/firefox-webext-browser/-/firefox-webext-browser-82.0.1.tgz",
-      "integrity": "sha512-odcPKiJ34N8k53clIWen3hLvl09ja7SQ9NqtUbgmqeJ/a/ZRQiF665iXSFPcnl6cBn2XQgEg2lsUUApYNiyj+g==",
-      "dev": true
-    },
     "@types/har-format": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.7.tgz",
@@ -16203,6 +16204,12 @@
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+    },
+    "@types/webextension-polyfill": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@types/webextension-polyfill/-/webextension-polyfill-0.8.0.tgz",
+      "integrity": "sha512-usmQx2snpNkVl2VoOGZCdrPnfHL+CjuSFy84ZdTwQ2b2cvyygF/zGW5YI6Zywk+bfq9zmYpORO9lmdN7DknpRw==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.30.0",
@@ -20947,9 +20954,9 @@
       "dev": true
     },
     "jest-worker": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.1.0.tgz",
-      "integrity": "sha512-mO4PHb2QWLn9yRXGp7rkvXLAYuxwhq1ZYUo0LoDhg8wqvv4QizP1ZWEJOeolgbEgAWZLIEU0wsku8J+lGWfBhg==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.0.tgz",
+      "integrity": "sha512-laB0ZVIBz+voh/QQy9dmUuuDsadixeerrKqyVpgPz+CCWiOYjOBabUXHIXZhsdvkWbLqSHbgkAHWl5cg24Q6RA==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -21412,9 +21419,9 @@
       "dev": true
     },
     "map-obj": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
-      "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "dev": true
     },
     "map-visit": {
@@ -23071,9 +23078,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -24401,9 +24408,9 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.0.tgz",
-      "integrity": "sha512-FpR4Qe0Yt4knSQ5u2bA1wkM0R8VlVsvhyfSHvomXRivS4vPLk0dJV2IhRBIHRABh7AFutdMeElIA5y1dETwMBg==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.4.tgz",
+      "integrity": "sha512-E2CkNMN+1cho04YpdANyRrn8CyN4yMy+WdFKZIySFZrGXZxJwJP6PMNGGc/Mcr6qygQHUUqRxnAPmi0M9f00XA==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -24991,10 +24998,16 @@
       "resolved": "https://registry.npmjs.org/webext-detect-page/-/webext-detect-page-3.0.2.tgz",
       "integrity": "sha512-CdU8W+6g05YAYrkdOfqUNrG9A4AybemgPGC+xeKnffRO4tbBrdYYy77qO0jlj7Udw9HXcE2xeFlEoW1ywjwTZw=="
     },
+    "webext-polyfill-kinda": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/webext-polyfill-kinda/-/webext-polyfill-kinda-0.1.1.tgz",
+      "integrity": "sha512-t0b+b9PRDrZ1f7+bJtRbsACdMzJM34AFxCpyG/nRnyR9XRbNkqXZgo4mEDu3FIrd5/o7MDlxHj3UYS5t0ZoLdw=="
+    },
     "webextension-polyfill": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.8.0.tgz",
-      "integrity": "sha512-a19+DzlT6Kp9/UI+mF9XQopeZ+n2ussjhxHJ4/pmIGge9ijCDz7Gn93mNnjpZAk95T4Tae8iHZ6sSf869txqiQ=="
+      "integrity": "sha512-a19+DzlT6Kp9/UI+mF9XQopeZ+n2ussjhxHJ4/pmIGge9ijCDz7Gn93mNnjpZAk95T4Tae8iHZ6sSf869txqiQ==",
+      "dev": true
     },
     "webidl-conversions": {
       "version": "4.0.2",
@@ -25003,9 +25016,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.51.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.51.1.tgz",
-      "integrity": "sha512-xsn3lwqEKoFvqn4JQggPSRxE4dhsRcysWTqYABAZlmavcoTmwlOb9b1N36Inbt/eIispSkuHa80/FJkDTPos1A==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.53.0.tgz",
+      "integrity": "sha512-RZ1Z3z3ni44snoWjfWeHFyzvd9HMVYDYC5VXmlYUT6NWgEOWdCNpad5Fve2CzzHoRED7WtsKe+FCyP5Vk4pWiQ==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -25036,9 +25049,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-          "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+          "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
           "dev": true,
           "peer": true
         },
@@ -25051,9 +25064,9 @@
           "requires": {}
         },
         "enhanced-resolve": {
-          "version": "5.8.2",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
-          "integrity": "sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==",
+          "version": "5.8.3",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
+          "integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -25079,18 +25092,18 @@
           }
         },
         "tapable": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
-          "integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==",
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+          "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
           "dev": true,
           "peer": true
         }
       }
     },
     "webpack-sources": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.0.tgz",
-      "integrity": "sha512-fahN08Et7P9trej8xz/Z7eRu8ltyiygEo/hnRi9KqBUs80KeDcnf96ZJo++ewWd84fEf3xSX9bp4ZS9hbw0OBw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.1.tgz",
+      "integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==",
       "dev": true,
       "peer": true
     },
@@ -25286,14 +25299,14 @@
       },
       "dependencies": {
         "@eslint/eslintrc": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.0.tgz",
-          "integrity": "sha512-FPnE4y+crrKBF0c9PckDHFuPDQl+wRX6S9jeSw2WwM2YNmrdRch3gx3DOTWpqpQu0G9yoJaeSSrJLiV/29tGyQ==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.1.tgz",
+          "integrity": "sha512-bkZOM1byYEdqFpWUzivekkhxD0diJ5NUQ7a2ReCP5+zvRu9T5R4t0cxVGqI1knerw3KzyuuMvGTHRihon0m3ng==",
           "dev": true,
           "requires": {
             "ajv": "^6.12.4",
             "debug": "^4.3.2",
-            "espree": "^8.0.0",
+            "espree": "^9.0.0",
             "globals": "^13.9.0",
             "ignore": "^4.0.6",
             "import-fresh": "^3.2.1",
@@ -25303,9 +25316,9 @@
           }
         },
         "acorn": {
-          "version": "8.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-          "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+          "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
           "dev": true
         },
         "array-union": {
@@ -25321,12 +25334,12 @@
           "dev": true
         },
         "espree": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-8.0.0.tgz",
-          "integrity": "sha512-y/+i23dwTjIDJrYCcjcAMr3c3UGbPIjC6THMQKjWmhP97fW0FPiI89kmpKfmgV/5jrkIi6toQP+CMm3qBE1Hig==",
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-9.0.0.tgz",
+          "integrity": "sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==",
           "dev": true,
           "requires": {
-            "acorn": "^8.4.1",
+            "acorn": "^8.5.0",
             "acorn-jsx": "^5.3.1",
             "eslint-visitor-keys": "^3.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -72,13 +72,13 @@
     "serialize-error": "^8.1.0",
     "type-fest": "^2.3.4",
     "webext-detect-page": "^3.0.2",
-    "webextension-polyfill": "^0.8.0"
+    "webext-polyfill-kinda": "^0.1.1"
   },
   "devDependencies": {
     "@parcel/config-webextension": "^2.0.0-rc.0",
     "@sindresorhus/tsconfig": "^2.0.0",
     "@types/chrome": "^0.0.154",
-    "@types/firefox-webext-browser": "^82.0.1",
+    "@types/webextension-polyfill": "^0.8.0",
     "@typescript-eslint/eslint-plugin": "^4.30.0",
     "@typescript-eslint/parser": "^4.30.0",
     "eslint": "^7.32.0",
@@ -91,6 +91,7 @@
     "npm-run-all": "^4.1.5",
     "parcel": "^2.0.0-rc.0",
     "typescript": "^4.4.2",
+    "webextension-polyfill": "^0.8.0",
     "xo": "^0.44.0"
   },
   "targets": {

--- a/test/demo-extension/contentscript/api.test.ts
+++ b/test/demo-extension/contentscript/api.test.ts
@@ -1,3 +1,4 @@
+import browser from "webextension-polyfill";
 import * as test from "fresh-tape";
 import { Target } from "../../../index";
 import {
@@ -153,11 +154,6 @@ async function init() {
 
     const request = getPageTitle({ tabId });
     await delay(1000); // Simulate a slow-loading tab
-    await browser.tabs.executeScript(tabId, {
-      // https://github.com/parcel-bundler/parcel/issues/5758
-      file:
-        "/up_/up_/node_modules/webextension-polyfill/dist/browser-polyfill.js",
-    });
     await browser.tabs.executeScript(tabId, {
       file: "contentscript/registration.js",
     });

--- a/test/demo-extension/manifest.json
+++ b/test/demo-extension/manifest.json
@@ -9,11 +9,7 @@
     "http://lite.cnn.com/*"
   ],
   "background": {
-    "scripts": [
-      "~node_modules/webextension-polyfill",
-      "background/registration.ts",
-      "contentscript/api.test.ts"
-    ]
+    "scripts": ["background/registration.ts", "contentscript/api.test.ts"]
   },
   "options_ui": {
     "page": "options.html",
@@ -23,23 +19,17 @@
     {
       "all_frames": true,
       "matches": ["https://legiblenews.com/*"],
-      "js": ["~node_modules/webextension-polyfill", "background/api.test.ts"]
+      "js": ["background/api.test.ts"]
     },
     {
       "all_frames": true,
       "matches": ["https://iframe-test-page.vercel.app/*"],
-      "js": [
-        "~node_modules/webextension-polyfill",
-        "contentscript/registration.ts"
-      ]
+      "js": ["contentscript/registration.ts"]
     },
     {
       "all_frames": true,
       "matches": ["https://text.npr.org/*"],
-      "js": [
-        "~node_modules/webextension-polyfill",
-        "contentscript/fixtures/unrelatedMessageListener.ts"
-      ]
+      "js": ["contentscript/fixtures/unrelatedMessageListener.ts"]
     }
   ]
 }

--- a/test/demo-extension/options.html
+++ b/test/demo-extension/options.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
 <meta charset="UTF-8" />
 <title>Options</title>
-<script src="~node_modules/webextension-polyfill"></script>
 <script type="module" src="background/api.test.ts"></script>


### PR DESCRIPTION
Abandoned because the types make it a a PITA. The problem is mainly due to the mismatch of `chrome` types that this would have to use and the `browser`-based types that we want to export (like `MessengerMeta`). 

Then there's also this wrecking havoc:

- https://github.com/fregante/webext-polyfill-kinda/issues/2