### PR TITLE
Add notification support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -109,13 +109,13 @@ async function handleMessage(
 }
 
 // Do not turn this into an `async` function; Notifications must turn `void`
-function handleAny(
+function manageConnection(
   type: string,
   options: Options,
   sendMessage: () => Promise<unknown>
 ): Promise<unknown> | void {
   if (!options.isNotification) {
-    return handleCall(type, sendMessage);
+    return manageMessage(type, sendMessage);
   }
 
   void sendMessage().catch((error: unknown) => {
@@ -123,7 +123,7 @@ function handleAny(
   });
 }
 
-async function handleCall(
+async function manageMessage(
   type: string,
   sendMessage: () => Promise<MessengerResponse | unknown>
 ): Promise<unknown> {
@@ -218,7 +218,7 @@ function getContentScriptMethod<
         { frameId: target.frameId ?? 0 }
       );
 
-    return handleAny(type, options, sendMessage);
+    return manageConnection(type, options, sendMessage);
   };
 
   return publicMethod as TPublicMethod;
@@ -250,7 +250,7 @@ function getMethod<
     const sendMessage = async () =>
       browser.runtime.sendMessage(makeMessage(type, args));
 
-    return handleAny(type, options, sendMessage);
+    return manageConnection(type, options, sendMessage);
   };
 
   return publicMethod as TPublicMethod;

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 import pRetry from "p-retry";
 import { deserializeError, ErrorObject, serializeError } from "serialize-error";
-import { Asyncify, ValueOf } from "type-fest";
+import { Asyncify, SetReturnType, ValueOf } from "type-fest";
 
 // The global interface is used to declare the types of the methods.
 // This "empty" declaration helps the local code understand what
@@ -191,7 +191,20 @@ function makeMessage(type: string, args: unknown[]): MessengerMessage {
  * Replicates the original method, including its types.
  * To be called in the sender’s end.
  */
-export function getContentScriptMethod<
+function getContentScriptMethod<
+  TType extends keyof MessengerMethods,
+  TMethod extends MessengerMethods[TType],
+  TPublicMethod extends PublicMethodWithTarget<TMethod>
+>(
+  type: TType,
+  options: { isNotification: true }
+): SetReturnType<TPublicMethod, void>;
+function getContentScriptMethod<
+  TType extends keyof MessengerMethods,
+  TMethod extends MessengerMethods[TType],
+  TPublicMethod extends PublicMethodWithTarget<TMethod>
+>(type: TType, options?: Options): TPublicMethod;
+function getContentScriptMethod<
   TType extends keyof MessengerMethods,
   TMethod extends MessengerMethods[TType],
   TPublicMethod extends PublicMethodWithTarget<TMethod>
@@ -215,7 +228,20 @@ export function getContentScriptMethod<
  * Replicates the original method, including its types.
  * To be called in the sender’s end.
  */
-export function getMethod<
+function getMethod<
+  TType extends keyof MessengerMethods,
+  TMethod extends MessengerMethods[TType],
+  TPublicMethod extends PublicMethod<TMethod>
+>(
+  type: TType,
+  options: { isNotification: true }
+): SetReturnType<TPublicMethod, void>;
+function getMethod<
+  TType extends keyof MessengerMethods,
+  TMethod extends MessengerMethods[TType],
+  TPublicMethod extends PublicMethod<TMethod>
+>(type: TType, options?: Options): TPublicMethod;
+function getMethod<
   TType extends keyof MessengerMethods,
   TMethod extends MessengerMethods[TType],
   TPublicMethod extends PublicMethod<TMethod>
@@ -230,7 +256,7 @@ export function getMethod<
   return publicMethod as TPublicMethod;
 }
 
-export function registerMethods(methods: Partial<MessengerMethods>): void {
+function registerMethods(methods: Partial<MessengerMethods>): void {
   for (const [type, method] of Object.entries(methods)) {
     if (handlers.has(type)) {
       throw new Error(`Handler already set for ${type}`);
@@ -242,3 +268,5 @@ export function registerMethods(methods: Partial<MessengerMethods>): void {
 
   browser.runtime.onMessage.addListener(onMessageListener);
 }
+
+export { getMethod, getContentScriptMethod, registerMethods };

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
       "@typescript-eslint/no-unsafe-member-access": "off",
       "import/extensions": "off",
       "import/no-unassigned-import": "off",
+      "unicorn/no-useless-undefined": "off",
       "node/file-extension-in-import": "off",
       "unicorn/filename-case": [
         "error",

--- a/test/demo-extension/background/api.ts
+++ b/test/demo-extension/background/api.ts
@@ -4,6 +4,9 @@ export const sum = getMethod("sum");
 export const throws = getMethod("throws");
 export const sumIfMeta = getMethod("sumIfMeta");
 export const notRegistered = getMethod("notRegistered");
+export const notRegisteredNotification = getMethod("notRegistered", {
+  isNotification: true,
+});
 export const getExtensionId = getMethod("getExtensionId");
 export const backgroundOnly = getMethod("backgroundOnly");
 export const getSelf = getMethod("getSelf");

--- a/test/demo-extension/contentscript/api.test.ts
+++ b/test/demo-extension/contentscript/api.test.ts
@@ -104,24 +104,16 @@ function runOnTarget(target: Target, expectedTitle: string) {
   });
 
   test(expectedTitle + ": notification should return undefined", async (t) => {
-    t.equals(await getPageTitleNotification(target), undefined);
+    // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- Testing for this specifically
+    t.equals(getPageTitleNotification(target), undefined);
   });
-
-  test(
-    expectedTitle + ": notification should return immediately",
-    async (t) => {
-      const startTime = Date.now();
-      await getPageTitleNotification(target);
-      const duration = Date.now() - startTime;
-      t.ok(duration < 50, `It should return immediately (took ${duration}ms)`);
-    }
-  );
 
   test(
     expectedTitle +
       ": notification without registered handlers should not throw",
     async (t) => {
-      t.equals(await notRegisteredNotification(target), undefined);
+      notRegisteredNotification(target);
+      t.pass();
     }
   );
 }
@@ -221,28 +213,20 @@ async function init() {
 
   test("notifications on non-existing targets", async (t) => {
     try {
-      t.is(
-        await getPageTitleNotification({ tabId: 9001 }),
-        undefined,
-        "Should return undefined"
-      );
+      getPageTitleNotification({ tabId: 9001 });
     } catch (error: unknown) {
       t.fail("Should not throw");
       throw error;
     }
+
+    t.pass();
   });
 
-  test("notifications when `registerMethod` was never called", async (t) => {
+  test("notifications when `registerMethod` was never called", async () => {
     const tab = await browser.tabs.create({
       url: "http://lite.cnn.com/",
     });
-    try {
-      await getPageTitleNotification({ tabId: tab.id! });
-    } catch (error: unknown) {
-      t.fail("Should not throw");
-      throw error;
-    }
-
+    getPageTitleNotification({ tabId: tab.id! });
     await browser.tabs.remove(tab.id!);
   });
 }

--- a/test/demo-extension/contentscript/api.test.ts
+++ b/test/demo-extension/contentscript/api.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import * as test from "fresh-tape";
 import { Target } from "../../../index";
 import {

--- a/test/demo-extension/contentscript/api.test.ts
+++ b/test/demo-extension/contentscript/api.test.ts
@@ -9,6 +9,8 @@ import {
   throws,
   notRegistered,
   getSelf,
+  notRegisteredNotification,
+  getPageTitleNotification,
 } from "./api";
 
 async function delay(timeout: number): Promise<void> {
@@ -100,6 +102,28 @@ function runOnTarget(target: Target, expectedTitle: string) {
     // Chrome (the types are just for Firefox) || Firefox
     t.true((self as any).origin === "null" || self.url === location.href);
   });
+
+  test(expectedTitle + ": notification should return undefined", async (t) => {
+    t.equals(await getPageTitleNotification(target), undefined);
+  });
+
+  test(
+    expectedTitle + ": notification should return immediately",
+    async (t) => {
+      const startTime = Date.now();
+      await getPageTitleNotification(target);
+      const duration = Date.now() - startTime;
+      t.ok(duration < 50, `It should return immediately (took ${duration}ms)`);
+    }
+  );
+
+  test(
+    expectedTitle +
+      ": notification without registered handlers should not throw",
+    async (t) => {
+      t.equals(await notRegisteredNotification(target), undefined);
+    }
+  );
 }
 
 async function init() {
@@ -188,8 +212,35 @@ async function init() {
       const duration = Date.now() - startTime;
       t.ok(
         duration > 4000 && duration < 5000,
-        `It should take between 4 and 5 seconds (took ${duration / 1000})s`
+        `It should take between 4 and 5 seconds (took ${duration / 1000}s)`
       );
+    }
+
+    await browser.tabs.remove(tab.id!);
+  });
+
+  test("notifications on non-existing targets", async (t) => {
+    try {
+      t.is(
+        await getPageTitleNotification({ tabId: 9001 }),
+        undefined,
+        "Should return undefined"
+      );
+    } catch (error: unknown) {
+      t.fail("Should not throw");
+      throw error;
+    }
+  });
+
+  test("notifications when `registerMethod` was never called", async (t) => {
+    const tab = await browser.tabs.create({
+      url: "http://lite.cnn.com/",
+    });
+    try {
+      await getPageTitleNotification({ tabId: tab.id! });
+    } catch (error: unknown) {
+      t.fail("Should not throw");
+      throw error;
     }
 
     await browser.tabs.remove(tab.id!);

--- a/test/demo-extension/contentscript/api.ts
+++ b/test/demo-extension/contentscript/api.ts
@@ -1,10 +1,17 @@
 import { getContentScriptMethod } from "../../../index";
 
 export const getPageTitle = getContentScriptMethod("getPageTitle");
+export const getPageTitleNotification = getContentScriptMethod("getPageTitle", {
+  isNotification: true,
+}); // Test-only; Notifications can't be getters
 export const setPageTitle = getContentScriptMethod("setPageTitle");
 export const closeSelf = getContentScriptMethod("closeSelf");
 export const sumIfMeta = getContentScriptMethod("sumIfMeta");
 export const contentScriptOnly = getContentScriptMethod("contentScriptOnly");
 export const throws = getContentScriptMethod("throws");
 export const notRegistered = getContentScriptMethod("notRegistered");
+export const notRegisteredNotification = getContentScriptMethod(
+  "notRegistered",
+  { isNotification: true }
+);
 export const getSelf = getContentScriptMethod("getSelf");


### PR DESCRIPTION
- Closes #23 
- Being tested in https://github.com/pixiebrix/pixiebrix-extension/pull/1460

I initially though about implementing `retry: false` to be more specific (it's not super clear what a notification is), but for our purposes we need this to do 3 things, so I've implemented it as a notification for now:

- no retry
- ignores all errors
- immediate return

At some point I'll adjust it to:

- [x] **not** return a Promise (so we're not forced to use `void myNotificationMethod()`)
- [x] fix the types to always return `void`: quite verbose but required (the types for `isNotification: true` are just wrong now)