### PR TITLE
Implement "to content script" via background page

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
     "sourceDir": "test/dist",
     "run": {
       "startUrl": [
-        "https://legiblenews.com/"
+        "https://legiblenews.com/",
+        "https://rawtext.club/"
       ]
     }
   }

--- a/test/demo-extension/background/api.ts
+++ b/test/demo-extension/background/api.ts
@@ -1,5 +1,11 @@
 import { getMethod } from "../../../index";
 
+// Dog-fooding, needed to run the tests
+export const openTab = getMethod("openTab");
+export const closeTab = getMethod("closeTab");
+export const getAllFrames = getMethod("getAllFrames");
+export const ensureScripts = getMethod("ensureScripts");
+
 export const sum = getMethod("sum");
 export const throws = getMethod("throws");
 export const sumIfMeta = getMethod("sumIfMeta");

--- a/test/demo-extension/background/registration.ts
+++ b/test/demo-extension/background/registration.ts
@@ -8,6 +8,7 @@ import { getExtensionId } from "./getExtensionId";
 import { backgroundOnly } from "./backgroundOnly";
 import { notRegistered } from "./notRegistered";
 import { getSelf } from "./getSelf";
+import { openTab, getAllFrames, ensureScripts, closeTab } from "./testingApi";
 
 declare global {
   interface MessengerMethods {
@@ -18,6 +19,10 @@ declare global {
     getExtensionId: typeof getExtensionId;
     backgroundOnly: typeof backgroundOnly;
     getSelf: typeof getSelf;
+    openTab: typeof openTab;
+    getAllFrames: typeof getAllFrames;
+    ensureScripts: typeof ensureScripts;
+    closeTab: typeof closeTab;
   }
 }
 
@@ -34,4 +39,8 @@ registerMethods({
   sumIfMeta,
   throws,
   getSelf,
+  openTab,
+  getAllFrames,
+  ensureScripts,
+  closeTab,
 });

--- a/test/demo-extension/background/testingApi.ts
+++ b/test/demo-extension/background/testingApi.ts
@@ -1,0 +1,33 @@
+export async function ensureScripts(tabId: number): Promise<void> {
+  await browser.tabs.executeScript(tabId, {
+    // https://github.com/parcel-bundler/parcel/issues/5758
+    file:
+      "/up_/up_/node_modules/webextension-polyfill/dist/browser-polyfill.js",
+  });
+  await browser.tabs.executeScript(tabId, {
+    file: "contentscript/registration.js",
+  });
+}
+
+export async function getAllFrames(
+  tabId: number
+): Promise<[parentFrame: number, iframe: number]> {
+  const [parentFrame, iframe] = await browser.webNavigation.getAllFrames({
+    tabId,
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return [parentFrame!.frameId, iframe!.frameId];
+}
+
+export async function openTab(url: string): Promise<number> {
+  const tab = await browser.tabs.create({
+    active: false,
+    url,
+  });
+  return tab.id!;
+}
+
+export async function closeTab(tabId: number): Promise<void> {
+  await browser.tabs.remove(tabId);
+}

--- a/test/demo-extension/contentscript/api.test.ts
+++ b/test/demo-extension/contentscript/api.test.ts
@@ -106,8 +106,13 @@ function runOnTarget(target: Target, expectedTitle: string) {
     const self = await getSelf(target);
     t.true(self instanceof Object);
     t.equals(self.id, chrome.runtime.id);
-    // Chrome (the types are just for Firefox) || Firefox
-    t.true((self as any).origin === "null" || self.url === location.href);
+
+    // TODO: `as any` because `self` is typed for Firefox only
+    // TODO: self.url always points to the background page, but it should include the current tab when forwarded https://github.com/pixiebrix/webext-messenger/issues/32
+    t.true(
+      (self as any).origin === "null" || // Chrome
+        self.url?.endsWith("/_generated_background_page.html") // Firefox
+    );
   });
 
   test(expectedTitle + ": notification should return undefined", async (t) => {

--- a/test/demo-extension/manifest.json
+++ b/test/demo-extension/manifest.json
@@ -34,6 +34,10 @@
       ]
     },
     {
+      "matches": ["https://rawtext.club/*"],
+      "js": ["~node_modules/webextension-polyfill", "contentscript/api.test.ts"]
+    },
+    {
       "all_frames": true,
       "matches": ["https://text.npr.org/*"],
       "js": [


### PR DESCRIPTION
- Closes #22 

Test:

1. Open https://rawtext.club
2. See it call the entire CS test suite for other tabs, through the background page

Next:

- [x] Cleanup
- [x] Double-check 

Notes:

- The API isn't elegant, but as always I'm focusing on tests and getting it working and fully typed before perfecting the API, which can change at any time between iterations