### PR TITLE
WIP: Add support for named targets (like the sidebar)

### DIFF
--- a/test/demo-extension/contentscript/api.test.ts
+++ b/test/demo-extension/contentscript/api.test.ts
@@ -1,6 +1,6 @@
 import * as test from "fresh-tape";
 import { isBackgroundPage } from "webext-detect-page";
-import { Target } from "../../../index";
+import { NamedTarget, Target } from "../../../index";
 import * as backgroundContext from "../background/api";
 import * as localContext from "../background/testingApi";
 import {
@@ -26,7 +26,7 @@ async function delay(timeout: number): Promise<void> {
   });
 }
 
-function runOnTarget(target: Target, expectedTitle: string) {
+function runOnTarget(target: Target | NamedTarget, expectedTitle: string) {
   test(expectedTitle + ": send message and get response", async (t) => {
     const title = await getPageTitle(target);
     t.equal(title, expectedTitle);
@@ -139,6 +139,7 @@ async function init() {
   // All `test` calls must be done synchronously, or else the runner assumes they're done
   runOnTarget({ tabId, frameId: parentFrame }, "Parent");
   runOnTarget({ tabId, frameId: iframe }, "Child");
+  runOnTarget({ tabId, name: "sidebar" }, "Child");
 
   test("should throw the right error when `registerMethod` was never called", async (t) => {
     const tabId = await openTab("https://text.npr.org/");


### PR DESCRIPTION
- Part of #41 

This enables:

```js
// action.ts
registerTarget("sidebar")
```

```js
// contentScript.ts
doSomething({name: "sidebar"}, "foo"); // Automatically uses the current tabId

// Anywhere
doSomething({name: "sidebar", tabId: 123}, "foo"); // Can be used from anywhere
```

With a simple change this will also allow name-less/tab-less calls to target the content script from the sidebar or other frames:

```ts
// action.ts
doSomething({}, "foo"); // Automatically uses the current tabId
```

---

`tabId`-less messages will always go through the background page, unfortunately, where the target is figured out either via "named targets" map or by using `TOP_FRAME_ID` on the sender’s `tabId`.