### PR TITLE
Catch unhandled messages in the sender’s end only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # https://pre-commit.com/hooks.html
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.2.1
+    rev: v2.4.1
     hooks:
       - id: prettier

--- a/index.ts
+++ b/index.ts
@@ -30,9 +30,8 @@ type PublicMethod<Method extends ValueOf<MessengerMethods>> = Asyncify<
   ActuallyOmitThisParameter<Method>
 >;
 
-type PublicMethodWithTarget<
-  Method extends ValueOf<MessengerMethods>
-> = WithTarget<PublicMethod<Method>>;
+type PublicMethodWithTarget<Method extends ValueOf<MessengerMethods>> =
+  WithTarget<PublicMethod<Method>>;
 
 export interface MessengerMeta {
   trace: browser.runtime.MessageSender[];
@@ -70,6 +69,10 @@ type MessengerMessage = Message & {
   /** Guarantees that a message is meant to be handled by this library */
   __webext_messenger__: true;
 };
+
+export class MessengerError extends Error {
+  override name = "MessengerError";
+}
 
 // eslint-disable-next-line @typescript-eslint/naming-convention -- Private key
 const __webext_messenger__ = true;
@@ -116,7 +119,7 @@ async function handleCall(
 async function handleMessage(
   message: Message,
   sender: MessengerMeta
-): Promise<MessengerResponse> {
+): Promise<MessengerResponse | void> {
   if (message.target) {
     const publicMethod = getContentScriptMethod(message.type);
     return handleCall(
@@ -131,7 +134,12 @@ async function handleMessage(
     return handleCall(message, sender, handler.apply(sender, message.args));
   }
 
-  throw new Error("No handler registered for " + message.type);
+  // More context in https://github.com/pixiebrix/webext-messenger/issues/45
+  console.warn(
+    "Messenger:",
+    message.type,
+    "received but ignored; No handlers were registered here"
+  );
 }
 
 // Do not turn this into an `async` function; Notifications must turn `void`
@@ -168,9 +176,11 @@ async function manageMessage(
       console.debug("Messenger:", type, "will retry");
     },
   });
+
   if (!isMessengerResponse(response)) {
-    // If the response is `undefined`, `registerMethod` was never called
-    throw new Error("No handlers registered in receiving end");
+    throw new MessengerError(
+      `No handler for ${type} was registered in the receiving end`
+    );
   }
 
   if ("error" in response) {
@@ -289,7 +299,7 @@ function getMethod<
         return handler.apply({ trace: [] }, args);
       }
 
-      throw new Error("No handler registered for " + type);
+      throw new MessengerError("No handler registered for " + type);
     }
 
     const sendMessage = async () =>
@@ -304,7 +314,7 @@ function getMethod<
 function registerMethods(methods: Partial<MessengerMethods>): void {
   for (const [type, method] of Object.entries(methods)) {
     if (handlers.has(type)) {
-      throw new Error(`Handler already set for ${type}`);
+      throw new MessengerError(`Handler already set for ${type}`);
     }
 
     console.debug(`Messenger: Registered`, type);

--- a/test/demo-extension/background/api.test.ts
+++ b/test/demo-extension/background/api.test.ts
@@ -77,7 +77,10 @@ test("should receive error from the background if it’s not registered", async 
       return;
     }
 
-    t.equal(error.message, "No handler registered for notRegistered");
+    t.equal(
+      error.message,
+      "No handler for notRegistered was registered in the receiving end"
+    );
   }
 });
 

--- a/test/demo-extension/contentscript/api.test.ts
+++ b/test/demo-extension/contentscript/api.test.ts
@@ -97,7 +97,10 @@ function runOnTarget(target: Target, expectedTitle: string) {
           return;
         }
 
-        t.equal(error.message, "No handler registered for notRegistered");
+        t.equal(
+          error.message,
+          "No handler for notRegistered was registered in the receiving end"
+        );
       }
     }
   );
@@ -155,7 +158,10 @@ async function init() {
         return;
       }
 
-      t.equal(error.message, "No handlers registered in receiving end");
+      t.equal(
+        error.message,
+        "No handler for getPageTitle was registered in the receiving end"
+      );
 
       await closeTab(tabId);
     }


### PR DESCRIPTION
- Fixes https://github.com/pixiebrix/webext-messenger/issues/45

Context:

- The receiving end would throw an error if a received message could not be handled
- We learned that this happens regularly because the `runtime.sendMessage` contacts every extension page instead of just the background page 

Solution:

- Only throw an error when **the sender** does not receive a Messenger response. This was already added in https://github.com/pixiebrix/webext-messenger/pull/15

This means that every context that receives unrecognized messages will just ignore them from now on.