### PR TITLE
Restore named targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "./this-stuff-is-just-for-local-parcel-tests": "./package.json",
     "./source/sender.js": "./source/sender.ts",
     "./source/receiver.js": "./source/receiver.ts",
+    "./source/namedTargets.js": "./source/namedTargets.ts",
     "./source/types.js": "./source/types.ts",
     "./source/shared.js": "./source/shared.ts"
   },

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,3 +1,7 @@
 export { registerMethods } from "./receiver.js";
 export { getContentScriptMethod, getMethod } from "./sender.js";
-export { MessengerMeta, Target } from "./types.js";
+export { MessengerMeta, NamedTarget, Target } from "./types.js";
+export { registerTarget } from "./namedTargets.js";
+import { initTargets } from "./namedTargets.js";
+
+initTargets();

--- a/source/namedTargets.ts
+++ b/source/namedTargets.ts
@@ -1,0 +1,69 @@
+import { isBackgroundPage } from "webext-detect-page";
+import { NamedTarget, Target, MessengerMeta } from "./types.js";
+import { errorNonExistingTarget, getMethod } from "./sender.js";
+import { registerMethods } from "./receiver.js";
+
+declare global {
+  interface MessengerMethods {
+    __webextMessengerTargetRegistration: typeof _registerTarget;
+  }
+}
+
+export function resolveNamedTarget(
+  target: NamedTarget,
+  sender?: browser.runtime.MessageSender
+): Target {
+  if (!isBackgroundPage()) {
+    throw new Error(
+      "Named targets can only be resolved in the background page"
+    );
+  }
+
+  const {
+    name,
+    tabId = sender?.tab?.id, // If not specified, try to use the sender’s
+  } = target;
+  if (typeof tabId === "undefined") {
+    throw new TypeError(
+      `${errorNonExistingTarget} The tab ID was not specified nor it was automatically determinable.`
+    );
+  }
+
+  const resolvedTarget = targets.get(`${tabId}%${name}`);
+  if (!resolvedTarget) {
+    throw new Error(
+      `${errorNonExistingTarget} Target named ${name} not registered for tab ${tabId}.`
+    );
+  }
+
+  return resolvedTarget;
+}
+
+// TODO: Remove targets after tab closes to avoid "memory leaks"
+export const targets = new Map<string, Target>();
+
+/** Register the current context so that it can be targeted with a name */
+export const registerTarget = getMethod("__webextMessengerTargetRegistration");
+
+async function _registerTarget(
+  this: MessengerMeta,
+  name: string
+): Promise<void> {
+  const sender = this.trace[0]!;
+  const tabId = sender.tab!.id!;
+  const { frameId } = sender;
+  targets.set(`${tabId}%${name}`, {
+    tabId,
+    frameId,
+  });
+
+  console.debug(`Messenger: Target "${name}" registered for tab ${tabId}`);
+}
+
+export function initTargets(): void {
+  if (isBackgroundPage()) {
+    registerMethods({
+      __webextMessengerTargetRegistration: _registerTarget,
+    });
+  }
+}

--- a/source/test/contentscript/api.test.ts
+++ b/source/test/contentscript/api.test.ts
@@ -1,7 +1,7 @@
 import test from "fresh-tape";
 import browser from "webextension-polyfill";
 import { isBackgroundPage } from "webext-detect-page";
-import { Target } from "../..";
+import { Target, NamedTarget } from "../..";
 import * as backgroundContext from "../background/api";
 import * as localContext from "../background/testingApi";
 import {
@@ -27,7 +27,7 @@ async function delay(timeout: number): Promise<void> {
   });
 }
 
-function runOnTarget(target: Target, expectedTitle: string) {
+function runOnTarget(target: Target | NamedTarget, expectedTitle: string) {
   test(expectedTitle + ": send message and get response", async (t) => {
     const title = await getPageTitle(target);
     t.equal(title, expectedTitle);
@@ -136,7 +136,7 @@ function runOnTarget(target: Target, expectedTitle: string) {
 
 async function init() {
   const tabId = await openTab(
-    "https://fregante.github.io/pixiebrix-testing-ground/Will-receive-CS-calls/Parent?iframe=./Child"
+    "https://fregante.github.io/pixiebrix-testing-ground/Will-receive-CS-calls/Parent?iframe=./Child&iframe=./Named-frame/Sidebar"
   );
 
   await delay(1000); // Let frames load so we can query them for the tests
@@ -145,6 +145,7 @@ async function init() {
   // All `test` calls must be done synchronously, or else the runner assumes they're done
   runOnTarget({ tabId, frameId: parentFrame }, "Parent");
   runOnTarget({ tabId, frameId: iframe }, "Child");
+  runOnTarget({ tabId, name: "sidebar" }, "Sidebar");
 
   test("should throw the right error when `registerMethod` was never called", async (t) => {
     const tabId = await openTab(

--- a/source/test/contentscript/registerSidebarTarget.ts
+++ b/source/test/contentscript/registerSidebarTarget.ts
@@ -1,0 +1,3 @@
+import { registerTarget } from "../..";
+
+void registerTarget("sidebar");

--- a/source/test/manifest.json
+++ b/source/test/manifest.json
@@ -26,6 +26,13 @@
       "js": ["contentscript/registration.ts"]
     },
     {
+      "all_frames": true,
+      "matches": [
+        "https://fregante.github.io/pixiebrix-testing-ground/Will-receive-CS-calls/Named-frame/Sidebar"
+      ],
+      "js": ["contentscript/registerSidebarTarget.ts"]
+    },
+    {
       "matches": [
         "https://fregante.github.io/pixiebrix-testing-ground/Will-call-other-CS-via-background"
       ],

--- a/source/types.ts
+++ b/source/types.ts
@@ -16,7 +16,7 @@ declare global {
 type WithTarget<Method> = Method extends (
   ...args: infer PreviousArguments
 ) => infer TReturnValue
-  ? (target: Target, ...args: PreviousArguments) => TReturnValue
+  ? (target: Target | NamedTarget, ...args: PreviousArguments) => TReturnValue
   : never;
 
 /* OmitThisParameter doesn't seem to do anything on pixiebrix-extension… */
@@ -69,7 +69,7 @@ export type Message<LocalArguments extends Arguments = Arguments> = {
   args: LocalArguments;
 
   /** If the message is being sent to an intermediary receiver, also set the target */
-  target?: Target;
+  target?: Target | NamedTarget;
 
   /** If the message is being sent to an intermediary receiver, also set the options */
   options?: Target;
@@ -83,4 +83,10 @@ export type MessengerMessage = Message & {
 export interface Target {
   tabId: number;
   frameId?: number;
+}
+
+export interface NamedTarget {
+  /** If the id is missing, it will use the sender’s tabId instead */
+  tabId?: number;
+  name: string;
 }


### PR DESCRIPTION
Restores https://github.com/pixiebrix/webext-messenger/pull/43 on the refactored codebase.

I'm not sure whether this will be final. The discoveries made in https://github.com/pixiebrix/webext-messenger/issues/45 may change/simplify this solution.

For example, without needing to register a context, a _named target_ could actually just match an extension page:

```js
getPageTitle({tabId: 12, page: "action.html"})
```

Then each receiver will match that information with itself and respond if it's a match. This is missing for that to happen

- [ ] Add native+automatic `whoAmI` call so that each target knows its own tabId

The good part of this is that it will allow direct communication from the content script.

It would also be a good opportunity to standardize the `target` parameter for the regular `getMethod` as well, since we'll be passing the desired target along with the message so that each target can respond safely.

```js
const doStuff = getMethod('DO_STUFF', {target: 'background'});
```
```js
await doStuff();
```

The named target above is made possible by:

- https://github.com/fregante/webext-detect-page/pull/17