### PR TITLE
Always specify a target

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webext-messenger",
-  "version": "0.13.0",
+  "version": "0.14.0-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webext-messenger",
-      "version": "0.13.0",
+      "version": "0.14.0-0",
       "license": "MIT",
       "dependencies": {
         "p-retry": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webext-messenger",
-  "version": "0.13.0",
+  "version": "0.14.0-0",
   "description": "Browser Extension component messaging framework",
   "keywords": [],
   "repository": "pixiebrix/webext-messenger",

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,3 +1,8 @@
 export { registerMethods } from "./receiver.js";
-export { getContentScriptMethod, getMethod } from "./sender.js";
+export {
+  messenger,
+  getMethod,
+  getNotifier,
+  backgroundTarget,
+} from "./sender.js";
 export { MessengerMeta, Target } from "./types.js";

--- a/source/receiver.ts
+++ b/source/receiver.ts
@@ -1,7 +1,7 @@
 import browser, { Runtime } from "webextension-polyfill";
 import { serializeError } from "serialize-error";
 
-import { getContentScriptMethod } from "./sender.js";
+import { messenger } from "./sender.js";
 import { Message, MessengerMeta, Method } from "./types.js";
 import {
   handlers,
@@ -46,8 +46,7 @@ function onMessageListener(
     }
 
     debug(type, "🔀 forwarded", { sender, target });
-    const publicMethod = getContentScriptMethod(type);
-    handleMessage = async () => publicMethod(target, ...args);
+    handleMessage = async () => messenger(type, {}, target, ...args);
   } else {
     const localHandler = handlers.get(type);
     if (!localHandler) {
@@ -82,7 +81,7 @@ export function registerMethods(methods: Partial<MessengerMethods>): void {
       throw new MessengerError(`Handler already set for ${type}`);
     }
 
-    console.debug(`Messenger: Registered`, type);
+    console.debug("Messenger: Registered", type);
     handlers.set(type, method as Method);
   }
 

--- a/source/sender.ts
+++ b/source/sender.ts
@@ -10,7 +10,7 @@ import {
   PublicMethodWithTarget,
   Options,
   Target,
-  UrlTarget,
+  PageTarget,
 } from "./types.js";
 import {
   isObject,
@@ -95,7 +95,7 @@ function messenger<
 >(
   type: Type,
   options: { isNotification: true },
-  target: Target | UrlTarget,
+  target: Target | PageTarget,
   ...args: Parameters<Method>
 ): void;
 function messenger<
@@ -105,7 +105,7 @@ function messenger<
 >(
   type: Type,
   options: Options,
-  target: Target | UrlTarget,
+  target: Target | PageTarget,
   ...args: Parameters<Method>
 ): ReturnValue;
 function messenger<
@@ -115,11 +115,11 @@ function messenger<
 >(
   type: Type,
   options: Options,
-  target: Target | UrlTarget,
+  target: Target | PageTarget,
   ...args: Parameters<Method>
 ): ReturnValue | void {
-  if ("url" in target) {
-    if (target.url === "background" && isBackgroundPage()) {
+  if ("page" in target) {
+    if (target.page === "background" && isBackgroundPage()) {
       const handler = handlers.get(type);
       if (handler) {
         warn(type, "is being handled locally");
@@ -161,7 +161,7 @@ function getMethod<
   Type extends keyof MessengerMethods,
   Method extends MessengerMethods[Type],
   PublicMethodType extends PublicMethod<Method>
->(type: Type, target: Target | UrlTarget): PublicMethodType;
+>(type: Type, target: Target | PageTarget): PublicMethodType;
 function getMethod<
   Type extends keyof MessengerMethods,
   Method extends MessengerMethods[Type],
@@ -174,7 +174,7 @@ function getMethod<
   PublicMethodWithDynamicTarget extends PublicMethodWithTarget<Method>
 >(
   type: Type,
-  target?: Target | UrlTarget
+  target?: Target | PageTarget
 ): PublicMethodType | PublicMethodWithDynamicTarget {
   if (arguments.length === 1) {
     return messenger.bind(undefined, type, {}) as PublicMethodWithDynamicTarget;
@@ -188,7 +188,7 @@ function getNotifier<
   Type extends keyof MessengerMethods,
   Method extends MessengerMethods[Type],
   PublicMethodType extends SetReturnType<PublicMethod<Method>, void>
->(type: Type, target: Target | UrlTarget): PublicMethodType;
+>(type: Type, target: Target | PageTarget): PublicMethodType;
 function getNotifier<
   Type extends keyof MessengerMethods,
   Method extends MessengerMethods[Type],
@@ -207,7 +207,7 @@ function getNotifier<
   >
 >(
   type: Type,
-  target?: Target | UrlTarget
+  target?: Target | PageTarget
 ): PublicMethodType | PublicMethodWithDynamicTarget {
   const options = { isNotification: true };
   if (arguments.length === 1) {
@@ -224,4 +224,4 @@ function getNotifier<
 }
 
 export { messenger, getMethod, getNotifier };
-export const backgroundTarget = { url: "background" };
+export const backgroundTarget: PageTarget = { page: "background" };

--- a/source/sender.ts
+++ b/source/sender.ts
@@ -1,6 +1,5 @@
 import browser from "webextension-polyfill";
 import pRetry from "p-retry";
-import { SetReturnType } from "type-fest";
 import { isBackgroundPage } from "webext-detect-page";
 import { deserializeError } from "serialize-error";
 
@@ -11,6 +10,7 @@ import {
   PublicMethodWithTarget,
   Options,
   Target,
+  UrlTarget,
 } from "./types.js";
 import {
   isObject,
@@ -20,6 +20,7 @@ import {
   debug,
   warn,
 } from "./shared.js";
+import { SetReturnType } from "type-fest";
 
 export const errorNonExistingTarget =
   "Could not establish connection. Receiving end does not exist.";
@@ -88,80 +89,41 @@ async function manageMessage(
   return response.value;
 }
 
-/**
- * Replicates the original method, including its types.
- * To be called in the sender’s end.
- */
-function getContentScriptMethod<
+function messenger<
   Type extends keyof MessengerMethods,
-  Method extends MessengerMethods[Type],
-  PublicMethod extends PublicMethodWithTarget<Method>
+  Method extends MessengerMethods[Type]
 >(
   type: Type,
-  options: { isNotification: true }
-): SetReturnType<PublicMethod, void>;
-function getContentScriptMethod<
+  options: { isNotification: true },
+  target: Target | UrlTarget,
+  ...args: Parameters<Method>
+): void;
+function messenger<
   Type extends keyof MessengerMethods,
   Method extends MessengerMethods[Type],
-  PublicMethod extends PublicMethodWithTarget<Method>
->(type: Type, options?: Options): PublicMethod;
-function getContentScriptMethod<
-  Type extends keyof MessengerMethods,
-  Method extends MessengerMethods[Type],
-  PublicMethod extends PublicMethodWithTarget<Method>
->(type: Type, options: Options = {}): PublicMethod {
-  const publicMethod = (target: Target, ...args: Parameters<Method>) => {
-    // Contexts without direct Tab access must go through background
-    if (!browser.tabs) {
-      return manageConnection(type, options, async () => {
-        debug(type, "↗️ sending message to runtime");
-        return browser.runtime.sendMessage(makeMessage(type, args, target));
-      });
-    }
-
-    // `frameId` must be specified. If missing, the message is sent to every frame
-    const { tabId, frameId = 0 } = target;
-
-    // Message tab directly
-    return manageConnection(type, options, async () => {
-      debug(type, "↗️ sending message to tab", tabId, "frame", frameId);
-      return browser.tabs.sendMessage(tabId, makeMessage(type, args), {
-        frameId,
-      });
-    });
-  };
-
-  return publicMethod as PublicMethod;
-}
-
-/**
- * Replicates the original method, including its types.
- * To be called in the sender’s end.
- */
-function getMethod<
-  Type extends keyof MessengerMethods,
-  Method extends MessengerMethods[Type],
-  PublicMethodType extends PublicMethod<Method>
+  ReturnValue extends ReturnType<Method>
 >(
   type: Type,
-  options: { isNotification: true }
-): SetReturnType<PublicMethodType, void>;
-function getMethod<
+  options: Options,
+  target: Target | UrlTarget,
+  ...args: Parameters<Method>
+): ReturnValue;
+function messenger<
   Type extends keyof MessengerMethods,
   Method extends MessengerMethods[Type],
-  PublicMethodType extends PublicMethod<Method>
->(type: Type, options?: Options): PublicMethodType;
-function getMethod<
-  Type extends keyof MessengerMethods,
-  Method extends MessengerMethods[Type],
-  PublicMethodType extends PublicMethod<Method>
->(type: Type, options: Options = {}): PublicMethodType {
-  const publicMethod = (...args: Parameters<Method>) => {
-    if (isBackgroundPage()) {
+  ReturnValue extends ReturnType<Method>
+>(
+  type: Type,
+  options: Options,
+  target: Target | UrlTarget,
+  ...args: Parameters<Method>
+): ReturnValue | void {
+  if ("url" in target) {
+    if (target.url === "background" && isBackgroundPage()) {
       const handler = handlers.get(type);
       if (handler) {
         warn(type, "is being handled locally");
-        return handler.apply({ trace: [] }, args);
+        return handler.apply({ trace: [] }, args) as ReturnValue;
       }
 
       throw new MessengerError("No handler registered for " + type);
@@ -172,10 +134,94 @@ function getMethod<
       return browser.runtime.sendMessage(makeMessage(type, args));
     };
 
-    return manageConnection(type, options, sendMessage);
-  };
+    return manageConnection(type, options, sendMessage) as ReturnValue;
+  }
 
-  return publicMethod as PublicMethodType;
+  // Contexts without direct Tab access must go through background
+  if (!browser.tabs) {
+    return manageConnection(type, options, async () => {
+      debug(type, "↗️ sending message to runtime");
+      return browser.runtime.sendMessage(makeMessage(type, args, target));
+    }) as ReturnValue;
+  }
+
+  // `frameId` must be specified. If missing, the message is sent to every frame
+  const { tabId, frameId = 0 } = target;
+
+  // Message tab directly
+  return manageConnection(type, options, async () => {
+    debug(type, "↗️ sending message to tab", tabId, "frame", frameId);
+    return browser.tabs.sendMessage(tabId, makeMessage(type, args), {
+      frameId,
+    });
+  }) as ReturnValue;
 }
 
-export { getContentScriptMethod, getMethod };
+function getMethod<
+  Type extends keyof MessengerMethods,
+  Method extends MessengerMethods[Type],
+  PublicMethodType extends PublicMethod<Method>
+>(type: Type, target: Target | UrlTarget): PublicMethodType;
+function getMethod<
+  Type extends keyof MessengerMethods,
+  Method extends MessengerMethods[Type],
+  PublicMethodWithDynamicTarget extends PublicMethodWithTarget<Method>
+>(type: Type): PublicMethodWithDynamicTarget;
+function getMethod<
+  Type extends keyof MessengerMethods,
+  Method extends MessengerMethods[Type],
+  PublicMethodType extends PublicMethod<Method>,
+  PublicMethodWithDynamicTarget extends PublicMethodWithTarget<Method>
+>(
+  type: Type,
+  target?: Target | UrlTarget
+): PublicMethodType | PublicMethodWithDynamicTarget {
+  if (arguments.length === 1) {
+    return messenger.bind(undefined, type, {}) as PublicMethodWithDynamicTarget;
+  }
+
+  // @ts-expect-error `bind` types are junk
+  return messenger.bind(undefined, type, {}, target) as PublicMethodType;
+}
+
+function getNotifier<
+  Type extends keyof MessengerMethods,
+  Method extends MessengerMethods[Type],
+  PublicMethodType extends SetReturnType<PublicMethod<Method>, void>
+>(type: Type, target: Target | UrlTarget): PublicMethodType;
+function getNotifier<
+  Type extends keyof MessengerMethods,
+  Method extends MessengerMethods[Type],
+  PublicMethodWithDynamicTarget extends SetReturnType<
+    PublicMethodWithTarget<Method>,
+    void
+  >
+>(type: Type): PublicMethodWithDynamicTarget;
+function getNotifier<
+  Type extends keyof MessengerMethods,
+  Method extends MessengerMethods[Type],
+  PublicMethodType extends SetReturnType<PublicMethod<Method>, void>,
+  PublicMethodWithDynamicTarget extends SetReturnType<
+    PublicMethodWithTarget<Method>,
+    void
+  >
+>(
+  type: Type,
+  target?: Target | UrlTarget
+): PublicMethodType | PublicMethodWithDynamicTarget {
+  const options = { isNotification: true };
+  if (arguments.length === 1) {
+    // @ts-expect-error `bind` types are junk
+    return messenger.bind(
+      undefined,
+      type,
+      options
+    ) as PublicMethodWithDynamicTarget;
+  }
+
+  // @ts-expect-error `bind` types are junk
+  return messenger.bind(undefined, type, options, target) as PublicMethodType;
+}
+
+export { messenger, getMethod, getNotifier };
+export const backgroundTarget = { url: "background" };

--- a/source/test/background/api.ts
+++ b/source/test/background/api.ts
@@ -1,18 +1,19 @@
-import { getMethod } from "../..";
+import { getMethod, getNotifier, backgroundTarget } from "../..";
 
 // Dog-fooding, needed to run the tests
-export const openTab = getMethod("openTab");
-export const closeTab = getMethod("closeTab");
-export const getAllFrames = getMethod("getAllFrames");
-export const ensureScripts = getMethod("ensureScripts");
+export const openTab = getMethod("openTab", backgroundTarget);
+export const closeTab = getMethod("closeTab", backgroundTarget);
+export const getAllFrames = getMethod("getAllFrames", backgroundTarget);
+export const ensureScripts = getMethod("ensureScripts", backgroundTarget);
 
-export const sum = getMethod("sum");
-export const throws = getMethod("throws");
-export const sumIfMeta = getMethod("sumIfMeta");
-export const notRegistered = getMethod("notRegistered");
-export const notRegisteredNotification = getMethod("notRegistered", {
-  isNotification: true,
-});
-export const getExtensionId = getMethod("getExtensionId");
-export const backgroundOnly = getMethod("backgroundOnly");
-export const getSelf = getMethod("getSelf");
+export const sum = getMethod("sum", backgroundTarget);
+export const throws = getMethod("throws", backgroundTarget);
+export const sumIfMeta = getMethod("sumIfMeta", backgroundTarget);
+export const notRegistered = getMethod("notRegistered", backgroundTarget);
+export const notRegisteredNotification = getNotifier(
+  "notRegistered",
+  backgroundTarget
+);
+export const getExtensionId = getMethod("getExtensionId", backgroundTarget);
+export const backgroundOnly = getMethod("backgroundOnly", backgroundTarget);
+export const getSelf = getMethod("getSelf", backgroundTarget);

--- a/source/test/contentscript/api.ts
+++ b/source/test/contentscript/api.ts
@@ -1,17 +1,12 @@
-import { getContentScriptMethod } from "../..";
+import { getNotifier, getMethod } from "../..";
 
-export const getPageTitle = getContentScriptMethod("getPageTitle");
-export const getPageTitleNotification = getContentScriptMethod("getPageTitle", {
-  isNotification: true,
-}); // Test-only; Notifications can't be getters
-export const setPageTitle = getContentScriptMethod("setPageTitle");
-export const closeSelf = getContentScriptMethod("closeSelf");
-export const sumIfMeta = getContentScriptMethod("sumIfMeta");
-export const contentScriptOnly = getContentScriptMethod("contentScriptOnly");
-export const throws = getContentScriptMethod("throws");
-export const notRegistered = getContentScriptMethod("notRegistered");
-export const notRegisteredNotification = getContentScriptMethod(
-  "notRegistered",
-  { isNotification: true }
-);
-export const getSelf = getContentScriptMethod("getSelf");
+export const getPageTitle = getMethod("getPageTitle");
+export const getPageTitleNotification = getNotifier("getPageTitle"); // Test-only; Notifications can't be getters
+export const setPageTitle = getMethod("setPageTitle");
+export const closeSelf = getMethod("closeSelf");
+export const sumIfMeta = getMethod("sumIfMeta");
+export const contentScriptOnly = getMethod("contentScriptOnly");
+export const throws = getMethod("throws");
+export const notRegistered = getMethod("notRegistered");
+export const notRegisteredNotification = getNotifier("notRegistered");
+export const getSelf = getMethod("getSelf");

--- a/source/types.ts
+++ b/source/types.ts
@@ -49,7 +49,6 @@ export type MessengerResponse = RawMessengerResponse & {
   __webextMessenger: true;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Unused, in practice
 type Arguments = any[];
 export type Method = (
   this: MessengerMeta,
@@ -83,4 +82,9 @@ export type MessengerMessage = Message & {
 export interface Target {
   tabId: number;
   frameId?: number;
+}
+
+export interface UrlTarget {
+  tabId?: number;
+  url: string;
 }

--- a/source/types.ts
+++ b/source/types.ts
@@ -84,7 +84,7 @@ export interface Target {
   frameId?: number;
 }
 
-export interface UrlTarget {
+export interface PageTarget {
   tabId?: number;
-  url: string;
+  page: string;
 }


### PR DESCRIPTION
## Context

Due to #45, we want to be able to specify the target every time, even for background pages, in order to be able to handle messages in specific contexts with certainty.


### Before


```js
const getTitle = getMethod("getTitle"); // Pre-bound for the background page
getTitle(); // No target necessary
```

### After

```js
const getTitle = getMethod("getTitle", {url: "background"}); // Explicitly targeted for the  background page
getTitle(); // Still no target necessary
```

## Changes

- Merge `getContentScriptMethod` into `getMethod`
- "Curry" `getMethod` so that you can specify the target either via `getMethod("x", target)` or `getMethod("x")("target")`, the latter matching the old `getContentScriptMethod`
- Extract `getNotifier` for notifications
- Create single `messenger` function to merge logic in a single place

These changes help reduce duplication between the 2 `get*Method` functions (which will be reduced further later) and make them more flexible regardless of the target, also preparing the code for #41

## Curry notes

I tried several currying and partial application modules but I think TypeScript just doesn't work well with this stuff. After currying the `messenger` I get meaningless types (i.e. the method’s parameter names are lost) or union types of all the methods (`getTitle` would be of type `() => string | number | {whateverObject: number}`)

I tried lodash.curry, lodash.partial, ramda, curry-rice, and I think a couple more copy-pasted solutions.

Maybe I'll try https://millsp.github.io/ts-toolbelt/modules/function_curry.html in the future

---

- Related to #41 
- Closes #51 