### PR TITLE
Add support for search parameters in named targets (`?id=UUID`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webext-messenger",
-  "version": "0.16.0",
+  "version": "0.17.0-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webext-messenger",
-      "version": "0.16.0",
+      "version": "0.17.0-0",
       "license": "MIT",
       "dependencies": {
         "p-retry": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webext-messenger",
-  "version": "0.16.0",
+  "version": "0.17.0-0",
   "description": "Browser Extension component messaging framework",
   "keywords": [],
   "repository": "pixiebrix/webext-messenger",


### PR DESCRIPTION
Probably the last piece for this issue, at least for extension pages:

- https://github.com/pixiebrix/webext-messenger/issues/41


Needs:

- [ ] tests