### PR TITLE
Don't register `__getTabData` in content scripts

### DIFF
--- a/source/handlers.ts
+++ b/source/handlers.ts
@@ -8,10 +8,16 @@ declare global {
   }
 }
 
-export const privateMethods = [__getTabData];
+const privateMethods = new Map<string, Method>([
+  ["__getTabData", __getTabData],
+]);
 
 export const handlers = new Map<string, Method>();
 
+export function getUserRegisterMethods(): Array<[string, Method]> {
+  return [...handlers].filter(([name]) => !privateMethods.has(name));
+}
+
 export function didUserRegisterMethods(): boolean {
-  return handlers.size > privateMethods.length;
+  return getUserRegisterMethods().length > 0;
 }

--- a/source/thisTarget.ts
+++ b/source/thisTarget.ts
@@ -1,8 +1,4 @@
-import {
-  isBackground,
-  isContentScript,
-  isExtensionContext,
-} from "webext-detect-page";
+import { isBackground, isContentScript, isWebPage } from "webext-detect-page";
 import { messenger } from "./sender.js";
 import { registerMethods } from "./receiver.js";
 import { AnyTarget, MessengerMeta, Sender } from "./types.js";
@@ -90,7 +86,7 @@ export async function nameThisTarget() {
   }
 }
 
-export function __getTabData(this: MessengerMeta): AnyTarget {
+export async function __getTabData(this: MessengerMeta): Promise<AnyTarget> {
   return { tabId: this.trace[0]?.tab?.id, frameId: this.trace[0]?.frameId };
 }
 
@@ -99,8 +95,9 @@ export function initPrivateApi(): void {
     thisTarget = { page: "background" };
   }
 
-  if (isExtensionContext()) {
-    // Any context can handler this message
+  if (!isWebPage()) {
+    // Excludes www scripts and content scripts
+    // Any `runtime` context can handler this message
     registerMethods({ __getTabData });
   }
 }


### PR DESCRIPTION
`__getTabData` is only useful on `runtime` pages, but it was being registered in every context.

Unfortunately https://github.com/pixiebrix/webext-messenger/pull/77 used this internal `registerMethods` call to detect the lack of user-registration. Without it, the listener is no longer registered and the message falls back to `Could not establish connection. Receiving end does not exist.`