### PR TITLE
Restore `__getTabData` handling in contexts without user methods

### DIFF
--- a/source/receiver.ts
+++ b/source/receiver.ts
@@ -67,12 +67,14 @@ async function handleMessage(
       wasForwarded: trace.length > 1,
     });
 
-    if (!didUserRegisterMethods()) {
-      throw new MessengerError(`No handlers registered in ${getContextName()}`);
-    }
-
     const localHandler = handlers.get(type);
     if (!localHandler) {
+      if (!didUserRegisterMethods()) {
+        throw new MessengerError(
+          `No handlers registered in ${getContextName()}`
+        );
+      }
+
       throw new MessengerError(
         `No handler registered for ${type} in ${getContextName()}`
       );

--- a/source/receiver.ts
+++ b/source/receiver.ts
@@ -70,6 +70,8 @@ async function handleMessage(
     const localHandler = handlers.get(type);
     if (!localHandler) {
       if (!didUserRegisterMethods()) {
+        // TODO: Test the handling of __getTabData in contexts that have no registered methods
+        // https://github.com/pixiebrix/webext-messenger/pull/82
         throw new MessengerError(
           `No handlers registered in ${getContextName()}`
         );


### PR DESCRIPTION
[A recent change](https://github.com/pixiebrix/webext-messenger/pull/77) caused the `__getTabData` to fail when the receiving context did not register any methods.

This PR moves the condition to the right place so that private methods can be handled.