### PR TITLE
Several `__getTabData` improvements

### DIFF
--- a/source/receiver.ts
+++ b/source/receiver.ts
@@ -1,5 +1,5 @@
 import { serializeError } from "serialize-error";
-import { getContextName, isBackground } from "webext-detect-page";
+import { getContextName } from "webext-detect-page";
 
 import { messenger } from "./sender.js";
 import { Message, MessengerMeta, Method, Sender } from "./types.js";
@@ -9,7 +9,7 @@ import {
   debug,
   __webextMessenger,
 } from "./shared.js";
-import { getActionForMessage, nameThisTarget } from "./thisTarget.js";
+import { getActionForMessage } from "./thisTarget.js";
 import { didUserRegisterMethods, handlers } from "./handlers.js";
 
 export function isMessengerMessage(message: unknown): message is Message {
@@ -32,7 +32,7 @@ function onMessageListener(
   }
 
   // Target check must be synchronous (`await` means we're handling the message)
-  const action = getActionForMessage(sender, message.target);
+  const action = getActionForMessage(sender, message);
   if (action === "ignore") {
     return;
   }
@@ -99,10 +99,6 @@ async function handleMessage(
 }
 
 export function registerMethods(methods: Partial<MessengerMethods>): void {
-  if (!isBackground()) {
-    void nameThisTarget();
-  }
-
   for (const [type, method] of Object.entries(methods)) {
     if (handlers.has(type)) {
       throw new MessengerError(`Handler already set for ${type}`);

--- a/source/thisTarget.ts
+++ b/source/thisTarget.ts
@@ -23,8 +23,8 @@ import { Entries } from "type-fest";
  *
  * If a broadcast message with `tabId` target is received before `__getTabData` is "received",
  * the message will be ignored and it can be retried. If `__getTabData` somehow fails,
- * the target will forever ignore any messages that require the `tabId`. An error message
- * would be shown in the context in that case.
+ * the target will forever ignore any messages that require the `tabId`. In that case,
+ * an error would be thrown once and will be visible in the console, uncaught.
  *
  * Content scripts do not use this logic at all at the moment because they're
  * always targeted via `tabId/frameId` combo and `tabs.sendMessage`.


### PR DESCRIPTION
- move info-getter call out of registerMethods so it's only ever called once (this never affected Pixiebrix)
- rename info-getter call to match its actual intent (getting the TAB information)
- track the status of the info getter: needed, pending, done, error
- make the `page` URL immediately available for named-target messages that don't need the tab information
- include name of ignored message and info-getter status in the debug log
- wrap any `__getTabData` errors into a more detailed error

✅  Semi-automated tests pass