### PR TITLE
Clarify and distinguish errors around missing/unresponsive targets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webext-messenger",
-  "version": "0.20.1",
+  "version": "0.21.0-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webext-messenger",
-      "version": "0.20.1",
+      "version": "0.21.0-0",
       "license": "MIT",
       "dependencies": {
         "p-retry": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webext-messenger",
-  "version": "0.20.1",
+  "version": "0.21.0-0",
   "description": "Browser Extension component messaging framework",
   "keywords": [],
   "repository": "pixiebrix/webext-messenger",

--- a/source/shared.ts
+++ b/source/shared.ts
@@ -1,4 +1,5 @@
 import { JsonObject } from "type-fest";
+import { errorConstructors } from "serialize-error";
 
 type ErrorObject = {
   name?: string;
@@ -28,6 +29,9 @@ export function isObject(value: unknown): value is Record<string, unknown> {
 export class MessengerError extends Error {
   override name = "MessengerError";
 }
+
+// @ts-expect-error Wrong `errorConstructors` types
+errorConstructors.set("MessengerError", MessengerError);
 
 // .bind preserves the call location in the console
 export const debug = logging ? console.debug.bind(console, "Messenger:") : noop;

--- a/source/test/contentscript/api.test.ts
+++ b/source/test/contentscript/api.test.ts
@@ -20,6 +20,34 @@ import {
 } from "./api.js";
 import { MessengerError } from "../../shared.js";
 
+function expectDuration(
+  t: test.Test,
+  actualDuration: number,
+  expectedDuration: number,
+  maximumDuration?: number
+) {
+  if (maximumDuration) {
+    t.ok(
+      actualDuration > expectedDuration && actualDuration < maximumDuration,
+      expectedDuration > 0
+        ? `It should take between ${expectedDuration / 1000} and ${
+            maximumDuration / 1000
+          } seconds (took ${actualDuration / 1000}s)`
+        : `It should take less than ${maximumDuration / 1000} seconds (took ${
+            actualDuration / 1000
+          }s)`
+    );
+  } else {
+    t.ok(
+      actualDuration > expectedDuration - 100 &&
+        actualDuration < expectedDuration + 100,
+      `It should take about ${expectedDuration / 1000}s (took ${
+        actualDuration / 1000
+      }s)`
+    );
+  }
+}
+
 function senderIsCurrentPage(
   t: test.Test,
   sender: Sender | undefined,
@@ -179,7 +207,7 @@ function runOnTarget(target: Target | PageTarget, expectedTitle: string) {
   );
 }
 
-async function init() {
+async function testEveryTarget() {
   const { tabId, parentFrame, iframe } = await createTargets();
 
   // All `test` calls must be done synchronously, or else the runner assumes they're done
@@ -187,6 +215,18 @@ async function init() {
   runOnTarget({ tabId, frameId: iframe }, "Child");
   runOnTarget({ tabId, page: "/iframe.html" }, "Extension frame");
 
+  test("should be able to close the tab from the content script", async (t) => {
+    await closeSelf({ tabId, frameId: parentFrame });
+    try {
+      // Since the tab was closed, this is expected to throw
+      t.notOk(await browser.tabs.get(tabId), "The tab should not be open");
+    } catch {
+      t.pass("The tab was closed");
+    }
+  });
+}
+
+function additionalTests() {
   test("should throw the right error when `registerMethod` was never called", async (t) => {
     const tabId = await openTab(
       "https://fregante.github.io/pixiebrix-testing-ground/Unrelated-CS-on-this-page"
@@ -213,16 +253,6 @@ async function init() {
     await closeTab(tabId);
   });
 
-  test("should be able to close the tab from the content script", async (t) => {
-    await closeSelf({ tabId, frameId: parentFrame });
-    try {
-      // Since the tab was closed, this is expected to throw
-      t.notOk(await browser.tabs.get(tabId), "The tab should not be open");
-    } catch {
-      t.pass("The tab was closed");
-    }
-  });
-
   test("retries until target is ready", async (t) => {
     const tabId = await openTab(
       "https://fregante.github.io/pixiebrix-testing-ground/No-static-content-scripts"
@@ -237,29 +267,33 @@ async function init() {
   });
 
   test("stops trying immediately if specific tab ID doesn't exist", async (t) => {
-    const request = getPageTitle({ tabId });
+    const request = getPageTitle({ tabId: 69_420 });
     const durationPromise = trackSettleTime(request);
 
     await expectRejection(t, request, new Error(errorTabDoesntExist));
 
-    const duration = await durationPromise;
-    t.ok(
-      duration < 100,
-      `It should take less than 100 ms (took ${duration}ms)`
-    );
+    expectDuration(t, await durationPromise, 0, 100);
   });
 
   test("stops trying immediately if specific tab ID doesn't exist, even if targeting a named target", async (t) => {
-    const request = getPageTitle({ tabId, page: "/void.html" });
+    const target = { tabId: 69_420, page: "/void.html" };
+    const request = getPageTitle(target);
     const durationPromise = trackSettleTime(request);
 
-    await expectRejection(t, request, new Error(errorTabDoesntExist));
-
-    const duration = await durationPromise;
-    t.ok(
-      duration < 100,
-      `It should take less than 100 ms (took ${duration}ms)`
-    );
+    if (isContentScript()) {
+      // CS-to-named-target can message it directly, but can't query the tab and quit early
+      await expectRejection(
+        t,
+        request,
+        new Error(
+          `The target ${JSON.stringify(target)} for getPageTitle was not found`
+        )
+      );
+      expectDuration(t, await durationPromise, 4000, 5000);
+    } else {
+      await expectRejection(t, request, new Error(errorTabDoesntExist));
+      expectDuration(t, await durationPromise, 0, 100);
+    }
   });
 
   test("stops trying immediately if tab is closed before the handler responds", async (t) => {
@@ -281,13 +315,7 @@ async function init() {
 
     await expectRejection(t, request, new Error(errorTargetClosedEarly));
 
-    const duration = await durationPromise;
-    t.ok(
-      duration > tabClosureTimeout - 100 && duration < tabClosureTimeout + 100,
-      `It should take about ${tabClosureTimeout / 1000}s (took ${
-        duration / 1000
-      }s)`
-    );
+    expectDuration(t, await durationPromise, tabClosureTimeout);
   });
 
   test("retries until it times out", async (t) => {
@@ -306,11 +334,7 @@ async function init() {
       )
     );
 
-    const duration = await durationPromise;
-    t.ok(
-      duration > 4000 && duration < 5000,
-      `It should take between 4 and 5 seconds (took ${duration / 1000}s)`
-    );
+    expectDuration(t, await durationPromise, 4000, 5000);
 
     await closeTab(tabId);
   });
@@ -329,11 +353,7 @@ async function init() {
       new Error("No handlers registered in contentScript")
     );
 
-    const duration = await durationPromise;
-    t.ok(
-      duration > 4000 && duration < 5000,
-      `It should take between 4 and 5 seconds (took ${duration / 1000}s)`
-    );
+    expectDuration(t, await durationPromise, 4000, 5000);
 
     await closeTab(tabId);
   });
@@ -351,11 +371,7 @@ async function init() {
       )
     );
 
-    const duration = await durationPromise;
-    t.ok(
-      duration > 4000 && duration < 5000,
-      `It should take between 4 and 5 seconds (took ${duration / 1000}s)`
-    );
+    expectDuration(t, await durationPromise, 4000, 5000);
   });
 
   test("throws the right error after retrying if a named target with tabId isn't found", async (t) => {
@@ -374,11 +390,7 @@ async function init() {
       )
     );
 
-    const duration = await durationPromise;
-    t.ok(
-      duration > 4000 && duration < 5000,
-      `It should take between 4 and 5 seconds (took ${duration / 1000}s)`
-    );
+    expectDuration(t, await durationPromise, 4000, 5000);
 
     await closeTab(tabId);
   });
@@ -403,4 +415,5 @@ async function init() {
   });
 }
 
-void init();
+testEveryTarget();
+additionalTests();

--- a/source/test/contentscript/api.test.ts
+++ b/source/test/contentscript/api.test.ts
@@ -415,5 +415,5 @@ function additionalTests() {
   });
 }
 
-testEveryTarget();
+void testEveryTarget();
 additionalTests();

--- a/source/test/contentscript/fixtures/unrelatedMessageListener.ts
+++ b/source/test/contentscript/fixtures/unrelatedMessageListener.ts
@@ -1,3 +1,13 @@
-browser.runtime.onMessage.addListener((message: unknown) => {
-  console.log("I’m an unrelated message listener. I’ve seen", { message });
-});
+browser.runtime.onMessage.addListener(
+  (message: unknown): Promise<string> | void => {
+    if ((message as any)?.type === "sleep") {
+      console.log(
+        "I’m an unrelated message listener, but I'm replying anyway to",
+        { message }
+      );
+      return Promise.resolve("/r/nosleep");
+    }
+
+    console.log("I’m an unrelated message listener. I’ve seen", { message });
+  }
+);


### PR DESCRIPTION
- Closes #78 

I'll likely want to see the impact on PB before merging this. I published a pre-release and I'll test it out tomorrow-ish. 

I'm trying to make sense of the errors that the messaging API and the Messenger throw. There are so many variations based on whether a target exists, _any_ target exists, the type of the target, the sender’s context, etc. 🙈  plus our own additional logic, forwarding, named targets, etc.🙉

Hopefully with these messages we get a better idea of what's happening and stop surfacing low-level errors like "Could not establish connection"