### PR TITLE
Skip webextension-polyfill

### DIFF
--- a/.parcelrc
+++ b/.parcelrc
@@ -1,6 +1,3 @@
 {
-	"extends": "@parcel/config-webextension",
-	"transformers": {
-		"*.md": ["@parcel/transformer-raw"]
-	}
+	"extends": "@parcel/config-webextension"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "serialize-error": "^11.0.0",
         "type-fest": "^3.2.0",
         "webext-detect-page": "^4.0.1",
+        "webext-polyfill-kinda": "^1.0.1",
         "webext-tools": "^1.1.0"
       },
       "devDependencies": {
@@ -15541,9 +15542,9 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
@@ -16348,7 +16349,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
     "node_modules/utility-types": {
@@ -16393,15 +16394,23 @@
         "url": "https://github.com/sponsors/fregante"
       }
     },
+    "node_modules/webext-content-scripts/node_modules/webext-polyfill-kinda": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/webext-polyfill-kinda/-/webext-polyfill-kinda-0.10.0.tgz",
+      "integrity": "sha512-Yz5WTwig5byFfMXgagtfaJkVU+RrnVqtL1hmvA+GIbpRaGKU1DIrFYHMUUFkeyFqxRSuhbOdLKzteXxCd6VNzA=="
+    },
     "node_modules/webext-detect-page": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/webext-detect-page/-/webext-detect-page-4.0.1.tgz",
       "integrity": "sha512-Y9Skw6/Uj0dGwOIidc1XqZ3neEbmuuT4BlkL/J4JHAo6fVznHIZq6/MWDsPGOA/jnNowiSXtHHh4S/TOxbl6bQ=="
     },
     "node_modules/webext-polyfill-kinda": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/webext-polyfill-kinda/-/webext-polyfill-kinda-0.10.0.tgz",
-      "integrity": "sha512-Yz5WTwig5byFfMXgagtfaJkVU+RrnVqtL1hmvA+GIbpRaGKU1DIrFYHMUUFkeyFqxRSuhbOdLKzteXxCd6VNzA=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/webext-polyfill-kinda/-/webext-polyfill-kinda-1.0.1.tgz",
+      "integrity": "sha512-j/0/lJFQ/ibGLXmQAwak4Dsb62Hkv6/OYK8ckW/yG00aMqo9dg6W7BNImbfo71FZVR45lYxPbfAU4YidxrGTzA==",
+      "funding": {
+        "url": "https://github.com/sponsors/fregante"
+      }
     },
     "node_modules/webext-tools": {
       "version": "1.1.0",
@@ -16415,6 +16424,11 @@
       "funding": {
         "url": "https://github.com/sponsors/fregante"
       }
+    },
+    "node_modules/webext-tools/node_modules/webext-polyfill-kinda": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/webext-polyfill-kinda/-/webext-polyfill-kinda-0.10.0.tgz",
+      "integrity": "sha512-Yz5WTwig5byFfMXgagtfaJkVU+RrnVqtL1hmvA+GIbpRaGKU1DIrFYHMUUFkeyFqxRSuhbOdLKzteXxCd6VNzA=="
     },
     "node_modules/webextension-polyfill": {
       "version": "0.10.0",
@@ -26539,9 +26553,9 @@
       }
     },
     "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -27138,7 +27152,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
     "utility-types": {
@@ -27175,6 +27189,13 @@
       "integrity": "sha512-gC+afnJFmsjBxtJAkG1bEUGnpedVMJq2wqEpswrZTuC3T4sAozkeJvC4GdZ/SjKDvj+HR0qcIQqVCWmlCv96DQ==",
       "requires": {
         "webext-polyfill-kinda": "^0.10.0"
+      },
+      "dependencies": {
+        "webext-polyfill-kinda": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/webext-polyfill-kinda/-/webext-polyfill-kinda-0.10.0.tgz",
+          "integrity": "sha512-Yz5WTwig5byFfMXgagtfaJkVU+RrnVqtL1hmvA+GIbpRaGKU1DIrFYHMUUFkeyFqxRSuhbOdLKzteXxCd6VNzA=="
+        }
       }
     },
     "webext-detect-page": {
@@ -27183,9 +27204,9 @@
       "integrity": "sha512-Y9Skw6/Uj0dGwOIidc1XqZ3neEbmuuT4BlkL/J4JHAo6fVznHIZq6/MWDsPGOA/jnNowiSXtHHh4S/TOxbl6bQ=="
     },
     "webext-polyfill-kinda": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/webext-polyfill-kinda/-/webext-polyfill-kinda-0.10.0.tgz",
-      "integrity": "sha512-Yz5WTwig5byFfMXgagtfaJkVU+RrnVqtL1hmvA+GIbpRaGKU1DIrFYHMUUFkeyFqxRSuhbOdLKzteXxCd6VNzA=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/webext-polyfill-kinda/-/webext-polyfill-kinda-1.0.1.tgz",
+      "integrity": "sha512-j/0/lJFQ/ibGLXmQAwak4Dsb62Hkv6/OYK8ckW/yG00aMqo9dg6W7BNImbfo71FZVR45lYxPbfAU4YidxrGTzA=="
     },
     "webext-tools": {
       "version": "1.1.0",
@@ -27195,6 +27216,13 @@
         "webext-content-scripts": "^1.0.1",
         "webext-detect-page": "^4.0.1",
         "webext-polyfill-kinda": "^0.10.0"
+      },
+      "dependencies": {
+        "webext-polyfill-kinda": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/webext-polyfill-kinda/-/webext-polyfill-kinda-0.10.0.tgz",
+          "integrity": "sha512-Yz5WTwig5byFfMXgagtfaJkVU+RrnVqtL1hmvA+GIbpRaGKU1DIrFYHMUUFkeyFqxRSuhbOdLKzteXxCd6VNzA=="
+        }
       }
     },
     "webextension-polyfill": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "serialize-error": "^11.0.0",
     "type-fest": "^3.2.0",
     "webext-detect-page": "^4.0.1",
+    "webext-polyfill-kinda": "^1.0.1",
     "webext-tools": "^1.1.0"
   },
   "devDependencies": {

--- a/source/receiver.ts
+++ b/source/receiver.ts
@@ -29,8 +29,9 @@ export function isMessengerMessage(message: unknown): message is Message {
 // MUST NOT be `async` or Promise-returning-only
 function onMessageListener(
   message: unknown,
-  sender: Sender
-): Promise<unknown> | void {
+  sender: Sender,
+  sendResponse: (response: unknown) => void
+): true | void {
   if (!isMessengerMessage(message)) {
     // TODO: Add test for this eventuality: ignore unrelated messages
     return;
@@ -42,7 +43,13 @@ function onMessageListener(
     return;
   }
 
-  return handleMessage(message, sender, action);
+  void handleMessage(message, sender, action).then(
+    sendResponse,
+    (error: unknown) => {
+      sendResponse({ __webextMessenger: true, error: serializeError(error) });
+    }
+  );
+  return true;
 }
 
 // This function can only be called when the message *will* be handled locally.

--- a/source/receiver.ts
+++ b/source/receiver.ts
@@ -113,7 +113,7 @@ export function registerMethods(methods: Partial<MessengerMethods>): void {
     handlers.set(type, method as Method);
   }
 
-  browser.runtime.onMessage.addListener(onMessageListener);
+  chrome.runtime.onMessage.addListener(onMessageListener);
 }
 
 /** Ensure/document that the current function was called via Messenger */

--- a/source/sender.ts
+++ b/source/sender.ts
@@ -1,3 +1,4 @@
+import chromeP from "webext-polyfill-kinda";
 import pRetry from "p-retry";
 import { isBackground } from "webext-detect-page";
 import { doesTabExist } from "webext-tools";
@@ -129,7 +130,7 @@ async function manageMessage(
           String(error.message).startsWith("No handlers registered in ")
         ) {
           if (
-            browser.tabs &&
+            chrome.tabs &&
             typeof target.tabId === "number" &&
             !(await doesTabExist(target.tabId))
           ) {
@@ -204,7 +205,7 @@ function messenger<
 
     const sendMessage = async () => {
       debug(type, "↗️ sending message to runtime");
-      return browser.runtime.sendMessage(
+      return chromeP.runtime.sendMessage(
         makeMessage(type, args, target, options)
       );
     };
@@ -213,10 +214,10 @@ function messenger<
   }
 
   // Contexts without direct Tab access must go through background
-  if (!browser.tabs) {
+  if (!chrome.tabs) {
     return manageConnection(type, options, target, async () => {
       debug(type, "↗️ sending message to runtime");
-      return browser.runtime.sendMessage(
+      return chromeP.runtime.sendMessage(
         makeMessage(type, args, target, options)
       );
     }) as ReturnValue;
@@ -228,7 +229,7 @@ function messenger<
   // Message tab directly
   return manageConnection(type, options, target, async () => {
     debug(type, "↗️ sending message to tab", tabId, "frame", frameId);
-    return browser.tabs.sendMessage(
+    return chromeP.tabs.sendMessage(
       tabId,
       makeMessage(type, args, target, options),
       {

--- a/source/test/background/testingApi.ts
+++ b/source/test/background/testingApi.ts
@@ -1,10 +1,11 @@
+import chromeP from "webext-polyfill-kinda";
 import { executeFunction } from "webext-content-scripts";
 
 export async function ensureScripts(tabId: number): Promise<void> {
-  await browser.tabs.executeScript(tabId, {
+  await chromeP.tabs.executeScript(tabId, {
     file: "webextensionPolyfill.js",
   });
-  await browser.tabs.executeScript(tabId, {
+  await chromeP.tabs.executeScript(tabId, {
     file: "contentscript/registration.js",
   });
 }
@@ -31,16 +32,16 @@ export async function createTargets(): Promise<Targets> {
   let frames;
   while (limit--) {
     // eslint-disable-next-line no-await-in-loop -- It's a retry loop
-    frames = await browser.webNavigation.getAllFrames({
+    frames = await chromeP.webNavigation.getAllFrames({
       tabId,
     });
 
-    if (frames.length >= 2) {
+    if (frames!.length >= 2) {
       // The local frame won't appear in Chrome 🤷‍♂️ but it will in Firefox
       return {
         tabId,
-        parentFrame: frames[0]!.frameId,
-        iframe: frames.find(
+        parentFrame: frames![0]!.frameId,
+        iframe: frames!.find(
           (frame) => frame.frameId > 0 && frame.url.startsWith("http")
         )!.frameId,
       };
@@ -57,7 +58,7 @@ export async function createTargets(): Promise<Targets> {
 }
 
 export async function openTab(url: string): Promise<number> {
-  const tab = await browser.tabs.create({
+  const tab = await chromeP.tabs.create({
     active: false,
     url,
   });
@@ -65,5 +66,5 @@ export async function openTab(url: string): Promise<number> {
 }
 
 export async function closeTab(tabId: number): Promise<void> {
-  await browser.tabs.remove(tabId);
+  await chromeP.tabs.remove(tabId);
 }

--- a/source/test/background/testingApi.ts
+++ b/source/test/background/testingApi.ts
@@ -33,7 +33,7 @@ export async function createTargets(): Promise<Targets> {
       tabId,
     });
 
-    if (frames.length >= 2) {
+    if (frames && frames.length >= 2) {
       // The local frame won't appear in Chrome 🤷‍♂️ but it will in Firefox
       return {
         tabId,

--- a/source/test/background/testingApi.ts
+++ b/source/test/background/testingApi.ts
@@ -3,9 +3,6 @@ import { executeFunction } from "webext-content-scripts";
 
 export async function ensureScripts(tabId: number): Promise<void> {
   await chromeP.tabs.executeScript(tabId, {
-    file: "webextensionPolyfill.js",
-  });
-  await chromeP.tabs.executeScript(tabId, {
     file: "contentscript/registration.js",
   });
 }
@@ -36,12 +33,12 @@ export async function createTargets(): Promise<Targets> {
       tabId,
     });
 
-    if (frames!.length >= 2) {
+    if (frames.length >= 2) {
       // The local frame won't appear in Chrome 🤷‍♂️ but it will in Firefox
       return {
         tabId,
-        parentFrame: frames![0]!.frameId,
-        iframe: frames!.find(
+        parentFrame: frames[0]!.frameId,
+        iframe: frames.find(
           (frame) => frame.frameId > 0 && frame.url.startsWith("http")
         )!.frameId,
       };

--- a/source/test/contentscript/api.test.ts
+++ b/source/test/contentscript/api.test.ts
@@ -1,3 +1,4 @@
+import chromeP from "webext-polyfill-kinda";
 import test from "tape";
 import { isBackground, isContentScript, isWebPage } from "webext-detect-page";
 import { type PageTarget, type Sender, type Target } from "../../index.js";
@@ -196,7 +197,7 @@ async function testEveryTarget() {
     await closeSelf({ tabId, frameId: parentFrame });
     try {
       // Since the tab was closed, this is expected to throw
-      t.notOk(await browser.tabs.get(tabId), "The tab should not be open");
+      t.notOk(await chromeP.tabs.get(tabId), "The tab should not be open");
     } catch {
       t.pass("The tab was closed");
     }

--- a/source/test/contentscript/api.test.ts
+++ b/source/test/contentscript/api.test.ts
@@ -317,7 +317,7 @@ function additionalTests() {
     await closeTab(tabId);
   });
 
-  test("retries until it times out even if webext-messenger was loaded (but nothing was registered)", async (t) => {
+  test.only("retries until it times out even if webext-messenger was loaded (but nothing was registered)", async (t) => {
     const tabId = await openTab(
       "https://fregante.github.io/pixiebrix-testing-ground/webext-messenger-was-imported-but-not-executed"
     );
@@ -393,5 +393,5 @@ function additionalTests() {
   });
 }
 
-void testEveryTarget();
+// void testEveryTarget();
 additionalTests();

--- a/source/test/contentscript/fixtures/unrelatedMessageListener.ts
+++ b/source/test/contentscript/fixtures/unrelatedMessageListener.ts
@@ -1,4 +1,4 @@
-browser.runtime.onMessage.addListener(
+chrome.runtime.onMessage.addListener(
   (message: unknown): Promise<string> | void => {
     if ((message as any)?.type === "sleep") {
       console.log(

--- a/source/test/contentscript/fixtures/unrelatedMessageListener.ts
+++ b/source/test/contentscript/fixtures/unrelatedMessageListener.ts
@@ -1,11 +1,13 @@
 chrome.runtime.onMessage.addListener(
-  (message: unknown): Promise<string> | void => {
+  (message: unknown, _, sendResponse): Promise<string> | void => {
     if ((message as any)?.type === "sleep") {
       console.log(
         "I’m an unrelated message listener, but I'm replying anyway to",
         { message }
       );
-      return Promise.resolve("/r/nosleep");
+
+      sendResponse("Good soup");
+      return;
     }
 
     console.log("I’m an unrelated message listener. I’ve seen", { message });

--- a/source/test/iframe.html
+++ b/source/test/iframe.html
@@ -12,5 +12,4 @@
     margin: 20px 0;
   }
 </style>
-<script type="module" src="webextensionPolyfill.ts"></script>
 <script type="module" src="contentscript/registration.ts"></script>

--- a/source/test/manifest.json
+++ b/source/test/manifest.json
@@ -4,11 +4,7 @@
   "manifest_version": 2,
   "permissions": ["webNavigation", "https://fregante.github.io/*"],
   "background": {
-    "scripts": [
-      "webextensionPolyfill.ts",
-      "background/registration.ts",
-      "contentscript/api.test.ts"
-    ]
+    "scripts": ["background/registration.ts", "contentscript/api.test.ts"]
   },
   "options_ui": {
     "page": "options.html",
@@ -20,37 +16,34 @@
       "matches": [
         "https://fregante.github.io/pixiebrix-testing-ground/Will-call-background-methods"
       ],
-      "js": ["webextensionPolyfill.ts", "background/api.test.ts"]
+      "js": ["background/api.test.ts"]
     },
     {
       "all_frames": true,
       "matches": [
         "https://fregante.github.io/pixiebrix-testing-ground/Will-receive-CS-calls/*"
       ],
-      "js": ["webextensionPolyfill.ts", "contentscript/registration.ts"]
+      "js": ["contentscript/registration.ts"]
     },
     {
       "matches": [
         "https://fregante.github.io/pixiebrix-testing-ground/Will-call-other-CS-via-background"
       ],
-      "js": ["webextensionPolyfill.ts", "contentscript/api.test.ts"]
+      "js": ["contentscript/api.test.ts"]
     },
     {
       "all_frames": true,
       "matches": [
         "https://fregante.github.io/pixiebrix-testing-ground/Unrelated-CS-on-this-page"
       ],
-      "js": [
-        "webextensionPolyfill.ts",
-        "contentscript/fixtures/unrelatedMessageListener.ts"
-      ]
+      "js": ["contentscript/fixtures/unrelatedMessageListener.ts"]
     },
     {
       "all_frames": true,
       "matches": [
         "https://fregante.github.io/pixiebrix-testing-ground/webext-messenger-was-imported-but-not-executed"
       ],
-      "js": ["webextensionPolyfill.ts", "contentscript/missedRegistration.ts"]
+      "js": ["contentscript/missedRegistration.ts"]
     }
   ],
   "web_accessible_resources": ["*.html", "**/*.ts"]

--- a/source/test/options.html
+++ b/source/test/options.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
 <meta charset="UTF-8" />
 <title>Options</title>
-<script type="module" src="webextensionPolyfill.ts"></script>
 <script type="module" src="background/api.test.ts"></script>

--- a/source/test/webextensionPolyfill.ts
+++ b/source/test/webextensionPolyfill.ts
@@ -1,4 +1,0 @@
-import browser from "webextension-polyfill";
-
-// @ts-expect-error Required until https://github.com/mozilla/webextension-polyfill/pull/376 or https://github.com/pixiebrix/webext-messenger/issues/67#issuecomment-1147121474
-globalThis.browser = browser;

--- a/source/types.ts
+++ b/source/types.ts
@@ -1,4 +1,3 @@
-import { type Runtime } from "webextension-polyfill";
 import { type Asyncify, type ValueOf } from "type-fest";
 import { type ErrorObject } from "serialize-error";
 
@@ -79,7 +78,7 @@ export type Message<LocalArguments extends Arguments = Arguments> = {
   options?: Options;
 };
 
-export type Sender = Runtime.MessageSender & { origin?: string }; // Chrome includes the origin
+export type Sender = chrome.runtime.MessageSender;
 
 export type MessengerMessage = Message & {
   /** Guarantees that a message is meant to be handled by this library */


### PR DESCRIPTION
- Fixes https://github.com/pixiebrix/webext-messenger/issues/67#issuecomment-1147121474

The polyfill provides little benefit here, especially since we're not dealing with Firefox anymore. Once we switch to MV3 we will be able to drop the polyfill completely, everywhere.

Not yet tested