### PR TITLE
Update tests to match Chrome’s new behavior 

### DIFF
--- a/source/test/contentscript/api.test.ts
+++ b/source/test/contentscript/api.test.ts
@@ -25,6 +25,8 @@ import {
 } from "./api.js";
 import { MessengerError } from "../../shared.js";
 
+const extensionUrl = new URL(chrome.runtime.getURL(""));
+
 function senderIsCurrentPage(
   t: test.Test,
   sender: Sender | undefined,
@@ -39,7 +41,8 @@ function senderisBackground(
   message: string
 ) {
   t.true(
-    sender?.origin === "null" || // Chrome
+    sender?.origin === extensionUrl.origin || // Chrome
+      sender?.origin === "null" || // Chrome, old
       sender!.url?.endsWith("/_generated_background_page.html"), // Firefox
     message
   );


### PR DESCRIPTION
The tests were failing because Chrome appears to have changed the `origin`. I don’t think this had any effect in the module itself