### PR TITLE
Add sequential number to logging

### DIFF
--- a/source/receiver.ts
+++ b/source/receiver.ts
@@ -56,17 +56,17 @@ async function handleMessage(
 ): Promise<unknown> {
   const { type, target, args, options = {} } = message;
 
-  const { trace = [] } = options;
+  const { trace = [], seq } = options;
   trace.push(sender);
   const meta: MessengerMeta = { trace };
 
   let handleMessage: () => Promise<unknown>;
 
   if (action === "forward") {
-    debug(type, "🔀 forwarded", { sender, target });
+    debug(type, seq, "🔀 forwarded", { sender, target });
     handleMessage = async () => messenger(type, meta, target, ...args);
   } else {
-    debug(type, "↘️ received in", getContextName(), {
+    debug(type, seq, "↘️ received in", getContextName(), {
       sender,
       args,
       wasForwarded: trace.length > 1,
@@ -99,7 +99,7 @@ async function handleMessage(
     })
   );
 
-  debug(type, "↗️ responding", response);
+  debug(type, seq, "↗️ responding", response);
   return { ...response, __webextMessenger };
 }
 

--- a/source/types.ts
+++ b/source/types.ts
@@ -68,6 +68,9 @@ export interface Options {
    */
   isNotification?: boolean;
   trace?: Sender[];
+
+  /** Automatically generated internally */
+  seq?: number;
 }
 
 export type Message<LocalArguments extends Arguments = Arguments> = {


### PR DESCRIPTION
- Closes #39 
- Closes #50 

## Example log

<img width="520" alt="Screenshot" src="https://github.com/pixiebrix/webext-messenger/assets/1402241/a431d710-1b88-4f70-8817-7dc300b54ed1">

## Finding the same message across contexts

<img width="759" alt="Screenshot 2" src="https://github.com/pixiebrix/webext-messenger/assets/1402241/c078ac76-5e4c-4017-818c-17dba4ff8034">

