### PR TITLE
Toggle logging at runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "distribution/index.js",
   "scripts": {
     "build": "tsc",
-    "demo:watch": "WEBEXT_MESSENGER_LOGGING=true parcel watch --no-cache --no-hmr",
+    "demo:watch": "parcel watch --no-cache --no-hmr",
     "demo:build": "parcel build --no-cache",
     "prepack": "tsc --sourceMap false",
     "test": "eslint . && tsc --noEmit",

--- a/source/index.ts
+++ b/source/index.ts
@@ -4,6 +4,8 @@ export * from "./receiver.js";
 export * from "./sender.js";
 export * from "./types.js";
 export { getThisFrame, getTopLevelFrame } from "./thisTarget.js";
+export { toggleLogging } from "./shared.js";
+
 import { initPrivateApi } from "./thisTarget.js";
 
 initPrivateApi();

--- a/source/receiver.ts
+++ b/source/receiver.ts
@@ -8,12 +8,7 @@ import {
   type Method,
   type Sender,
 } from "./types.js";
-import {
-  isObject,
-  MessengerError,
-  debug,
-  __webextMessenger,
-} from "./shared.js";
+import { isObject, MessengerError, log, __webextMessenger } from "./shared.js";
 import { getActionForMessage } from "./thisTarget.js";
 import { didUserRegisterMethods, handlers } from "./handlers.js";
 
@@ -63,10 +58,10 @@ async function handleMessage(
   let handleMessage: () => Promise<unknown>;
 
   if (action === "forward") {
-    debug(type, "🔀 forwarded", { sender, target });
+    log.debug(type, "🔀 forwarded", { sender, target });
     handleMessage = async () => messenger(type, meta, target, ...args);
   } else {
-    debug(type, "↘️ received in", getContextName(), {
+    log.debug(type, "↘️ received in", getContextName(), {
       sender,
       args,
       wasForwarded: trace.length > 1,
@@ -99,7 +94,7 @@ async function handleMessage(
     })
   );
 
-  debug(type, "↗️ responding", response);
+  log.debug(type, "↗️ responding", response);
   return { ...response, __webextMessenger };
 }
 
@@ -109,7 +104,7 @@ export function registerMethods(methods: Partial<MessengerMethods>): void {
       throw new MessengerError(`Handler already set for ${type}`);
     }
 
-    debug("Registered", type);
+    log.debug("Registered", type);
     handlers.set(type, method as Method);
   }
 

--- a/source/shared.ts
+++ b/source/shared.ts
@@ -28,12 +28,15 @@ errorConstructors.set("MessengerError", MessengerError);
 const debug = console.debug.bind(console, "Messenger:");
 const warn = console.warn.bind(console, "Messenger:");
 
-export const log = { debug: noop, warn: noop };
+export const log = { debug, warn };
 
 export function toggleLogging(enabled: boolean): void {
   log.debug = enabled ? debug : noop;
   log.warn = enabled ? warn : noop;
 }
+
+// Default to "no logs"
+toggleLogging(false);
 
 export function isErrorObject(error: unknown): error is ErrorObject {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- This is a type guard function and it uses ?.

--- a/source/shared.ts
+++ b/source/shared.ts
@@ -8,22 +8,13 @@ type ErrorObject = {
   code?: string;
 } & JsonObject;
 
-const logging = (() => {
-  try {
-    // @ts-expect-error it would break Webpack
-    return process.env.WEBEXT_MESSENGER_LOGGING === "true";
-  } catch {
-    return false;
-  }
-})();
-
-function noop() {
-  /* */
-}
-
 export const __webextMessenger = true;
 export function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function noop() {
+  /* */
 }
 
 export class MessengerError extends Error {
@@ -34,8 +25,15 @@ export class MessengerError extends Error {
 errorConstructors.set("MessengerError", MessengerError);
 
 // .bind preserves the call location in the console
-export const debug = logging ? console.debug.bind(console, "Messenger:") : noop;
-export const warn = logging ? console.warn.bind(console, "Messenger:") : noop;
+const debug = console.debug.bind(console, "Messenger:");
+const warn = console.warn.bind(console, "Messenger:");
+
+export const log = { debug: noop, warn: noop };
+
+export function toggleLogging(enabled: boolean): void {
+  log.debug = enabled ? debug : noop;
+  log.warn = enabled ? warn : noop;
+}
 
 export function isErrorObject(error: unknown): error is ErrorObject {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- This is a type guard function and it uses ?.

--- a/source/thisTarget.ts
+++ b/source/thisTarget.ts
@@ -14,7 +14,7 @@ import {
   type Sender,
   type FrameTarget,
 } from "./types.js";
-import { debug, MessengerError, once } from "./shared.js";
+import { log, MessengerError, once } from "./shared.js";
 import { type Entries } from "type-fest";
 
 /**
@@ -116,7 +116,7 @@ export function getActionForMessage(
   const isThisTarget = compareTargets(to, thisTarget);
 
   if (!isThisTarget) {
-    debug(message.type, "🤫 ignored due to target mismatch", {
+    log.debug(message.type, "🤫 ignored due to target mismatch", {
       requestedTarget: to,
       thisTarget,
       tabDataStatus,


### PR DESCRIPTION
- Closes #130 

This defaults the module to no logs, but allows toggling it at runtime.

In the extension you can then have a flag that calls this function in every open context (or at the next refresh)