### PR TITLE
Only forward messages when received in the background page

### DIFF
--- a/source/thisTarget.ts
+++ b/source/thisTarget.ts
@@ -104,7 +104,13 @@ export function getActionForMessage(
 
   // We're in an extension page, but the target is not one.
   if (!to.page) {
-    return "forward";
+    // Only the background page can forward messages at the moment
+    // https://github.com/pixiebrix/webext-messenger/issues/85
+    if (isBackground()) {
+      return "forward";
+    }
+
+    return "ignore";
   }
 
   // Set "this" tab to the current tabId


### PR DESCRIPTION
Tentatively sending a PR to fix https://github.com/pixiebrix/webext-messenger/issues/85

The relevant initial messenger also mentions "though the background page" 

https://github.com/pixiebrix/webext-messenger/blob/477016d62004e2ce828879a758fdc81f5ad1f5c8/source/sender.ts#L215-L223

And since we don't support Firefox, routing through the content script won't be necessary.