### PR TITLE
Make retry logging more readable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11560,9 +11560,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001346",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001346.tgz",
-      "integrity": "sha512-q6ibZUO2t88QCIPayP/euuDREq+aMAxFE5S70PkrLh0iTDj/zEhgvJRKC2+CvXY6EWc6oQwUR48lL5vCW6jiXQ==",
+      "version": "1.0.30001534",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001534.tgz",
+      "integrity": "sha512-vlPVrhsCS7XaSh2VvWluIQEzVhefrUQcEsQWSS5A5V+dM07uv1qHeQzAOTGIMy9i3e9bH15+muvI/UHojVgS/Q==",
       "dev": true,
       "funding": [
         {
@@ -11572,6 +11572,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -24246,9 +24250,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001346",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001346.tgz",
-      "integrity": "sha512-q6ibZUO2t88QCIPayP/euuDREq+aMAxFE5S70PkrLh0iTDj/zEhgvJRKC2+CvXY6EWc6oQwUR48lL5vCW6jiXQ==",
+      "version": "1.0.30001534",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001534.tgz",
+      "integrity": "sha512-vlPVrhsCS7XaSh2VvWluIQEzVhefrUQcEsQWSS5A5V+dM07uv1qHeQzAOTGIMy9i3e9bH15+muvI/UHojVgS/Q==",
       "dev": true
     },
     "chalk": {

--- a/source/sender.ts
+++ b/source/sender.ts
@@ -38,6 +38,10 @@ function isMessengerResponse(response: unknown): response is MessengerResponse {
   return isObject(response) && response["__webextMessenger"] === true;
 }
 
+function attemptLog(attemptNumber: number): string {
+  return attemptNumber > 1 ? `(try: ${attemptNumber})` : "";
+}
+
 function makeMessage(
   type: keyof MessengerMethods,
   args: unknown[],
@@ -58,13 +62,13 @@ function manageConnection(
   type: string,
   options: Options,
   target: AnyTarget,
-  sendMessage: () => Promise<unknown>
+  sendMessage: (attempt: number) => Promise<unknown>
 ): Promise<unknown> | void {
   if (!options.isNotification) {
     return manageMessage(type, target, sendMessage);
   }
 
-  void sendMessage().catch((error: unknown) => {
+  void sendMessage(1).catch((error: unknown) => {
     debug(type, "notification failed", { error });
   });
 }
@@ -72,11 +76,11 @@ function manageConnection(
 async function manageMessage(
   type: string,
   target: AnyTarget,
-  sendMessage: () => Promise<unknown>
+  sendMessage: (attempt: number) => Promise<unknown>
 ): Promise<unknown> {
   const response = await pRetry(
-    async () => {
-      const response = await sendMessage();
+    async (attemptNumber) => {
+      const response = await sendMessage(attemptNumber);
 
       if (isMessengerResponse(response)) {
         return response;
@@ -136,7 +140,7 @@ async function manageMessage(
             throw new Error(errorTabDoesntExist);
           }
 
-          debug(type, "will retry. Attempt", error.attemptNumber);
+          // Fall through, will retry
         } else {
           throw error;
         }
@@ -202,8 +206,8 @@ function messenger<
       throw new MessengerError("No handler registered locally for " + type);
     }
 
-    const sendMessage = async () => {
-      debug(type, "↗️ sending message to runtime");
+    const sendMessage = async (attemptNumber: number) => {
+      debug(type, "↗️ sending message to runtime", attemptLog(attemptNumber));
       return browser.runtime.sendMessage(
         makeMessage(type, args, target, options)
       );
@@ -214,28 +218,45 @@ function messenger<
 
   // Contexts without direct Tab access must go through background
   if (!browser.tabs) {
-    return manageConnection(type, options, target, async () => {
-      debug(type, "↗️ sending message to runtime");
-      return browser.runtime.sendMessage(
-        makeMessage(type, args, target, options)
-      );
-    }) as ReturnValue;
+    return manageConnection(
+      type,
+      options,
+      target,
+      async (attemptNumber: number) => {
+        debug(type, "↗️ sending message to runtime", attemptLog(attemptNumber));
+        return browser.runtime.sendMessage(
+          makeMessage(type, args, target, options)
+        );
+      }
+    ) as ReturnValue;
   }
 
   // `frameId` must be specified. If missing, the message is sent to every frame
   const { tabId, frameId = 0 } = target;
 
   // Message tab directly
-  return manageConnection(type, options, target, async () => {
-    debug(type, "↗️ sending message to tab", tabId, "frame", frameId);
-    return browser.tabs.sendMessage(
-      tabId,
-      makeMessage(type, args, target, options),
-      {
+  return manageConnection(
+    type,
+    options,
+    target,
+    async (attemptNumber: number) => {
+      debug(
+        type,
+        "↗️ sending message to tab",
+        tabId,
+        "frame",
         frameId,
-      }
-    );
-  }) as ReturnValue;
+        attemptLog(attemptNumber)
+      );
+      return browser.tabs.sendMessage(
+        tabId,
+        makeMessage(type, args, target, options),
+        {
+          frameId,
+        }
+      );
+    }
+  ) as ReturnValue;
 }
 
 function getMethod<

--- a/source/sender.ts
+++ b/source/sender.ts
@@ -38,8 +38,8 @@ function isMessengerResponse(response: unknown): response is MessengerResponse {
   return isObject(response) && response["__webextMessenger"] === true;
 }
 
-function attemptLog(attemptNumber: number): string {
-  return attemptNumber > 1 ? `(try: ${attemptNumber})` : "";
+function attemptLog(attemptCount: number): string {
+  return attemptCount > 1 ? `(try: ${attemptCount})` : "";
 }
 
 function makeMessage(
@@ -79,8 +79,8 @@ async function manageMessage(
   sendMessage: (attempt: number) => Promise<unknown>
 ): Promise<unknown> {
   const response = await pRetry(
-    async (attemptNumber) => {
-      const response = await sendMessage(attemptNumber);
+    async (attemptCount) => {
+      const response = await sendMessage(attemptCount);
 
       if (isMessengerResponse(response)) {
         return response;
@@ -206,8 +206,8 @@ function messenger<
       throw new MessengerError("No handler registered locally for " + type);
     }
 
-    const sendMessage = async (attemptNumber: number) => {
-      debug(type, "↗️ sending message to runtime", attemptLog(attemptNumber));
+    const sendMessage = async (attemptCount: number) => {
+      debug(type, "↗️ sending message to runtime", attemptLog(attemptCount));
       return browser.runtime.sendMessage(
         makeMessage(type, args, target, options)
       );
@@ -222,8 +222,8 @@ function messenger<
       type,
       options,
       target,
-      async (attemptNumber: number) => {
-        debug(type, "↗️ sending message to runtime", attemptLog(attemptNumber));
+      async (attemptCount: number) => {
+        debug(type, "↗️ sending message to runtime", attemptLog(attemptCount));
         return browser.runtime.sendMessage(
           makeMessage(type, args, target, options)
         );
@@ -239,14 +239,14 @@ function messenger<
     type,
     options,
     target,
-    async (attemptNumber: number) => {
+    async (attemptCount: number) => {
       debug(
         type,
         "↗️ sending message to tab",
         tabId,
         "frame",
         frameId,
-        attemptLog(attemptNumber)
+        attemptLog(attemptCount)
       );
       return browser.tabs.sendMessage(
         tabId,


### PR DESCRIPTION
The previous logging was easy to handle but hard to follow and noisy. I think this will help debugging

## Before

<img width="355" alt="Screenshot 3" src="https://github.com/pixiebrix/webext-messenger/assets/1402241/9abb6c1c-07f9-4234-b8b8-e0ca9ecdd15f">

## After

<img width="410" alt="Screenshot 4" src="https://github.com/pixiebrix/webext-messenger/assets/1402241/a1f804f6-562a-4803-9fdd-1355e4096a4a">

