### PR TITLE
Dispatch events on retries

### DIFF
--- a/source/events.ts
+++ b/source/events.ts
@@ -1,0 +1,1 @@
+export const events = new EventTarget();

--- a/source/index.ts
+++ b/source/index.ts
@@ -3,6 +3,7 @@
 export * from "./receiver.js";
 export * from "./sender.js";
 export * from "./types.js";
+export * from "./events.js";
 export { getThisFrame, getTopLevelFrame } from "./thisTarget.js";
 import { initPrivateApi } from "./thisTarget.js";
 

--- a/source/sender.ts
+++ b/source/sender.ts
@@ -22,6 +22,7 @@ import {
 } from "./shared.js";
 import { type SetReturnType } from "type-fest";
 import { handlers } from "./handlers.js";
+import { events } from "./events.js";
 
 const _errorNonExistingTarget =
   "Could not establish connection. Receiving end does not exist.";
@@ -116,6 +117,10 @@ async function manageMessage(
       factor: 1.3,
       maxRetryTime: 4000,
       async onFailedAttempt(error) {
+        events.dispatchEvent(
+          new CustomEvent("failed-attempt", { detail: error })
+        );
+
         if (error.message === _errorTargetClosedEarly) {
           throw new Error(errorTargetClosedEarly);
         }
@@ -148,6 +153,10 @@ async function manageMessage(
         `The target ${JSON.stringify(target)} for ${type} was not found`
       );
     }
+
+    events.dispatchEvent(
+      new CustomEvent("attempts-exhausted", { detail: error })
+    );
 
     throw error;
   });

--- a/source/sender.ts
+++ b/source/sender.ts
@@ -118,7 +118,9 @@ async function manageMessage(
       maxRetryTime: 4000,
       async onFailedAttempt(error) {
         events.dispatchEvent(
-          new CustomEvent("failed-attempt", { detail: { type, target, error } })
+          new CustomEvent("failed-attempt", {
+            detail: { type, target, error, attemptCount: error.attemptNumber },
+          })
         );
 
         if (error.message === _errorTargetClosedEarly) {

--- a/source/sender.ts
+++ b/source/sender.ts
@@ -118,7 +118,7 @@ async function manageMessage(
       maxRetryTime: 4000,
       async onFailedAttempt(error) {
         events.dispatchEvent(
-          new CustomEvent("failed-attempt", { detail: error })
+          new CustomEvent("failed-attempt", { detail: { type, target, error } })
         );
 
         if (error.message === _errorTargetClosedEarly) {
@@ -155,7 +155,7 @@ async function manageMessage(
     }
 
     events.dispatchEvent(
-      new CustomEvent("attempts-exhausted", { detail: error })
+      new CustomEvent("attempts-exhausted", { detail: { type, target, error } })
     );
 
     throw error;


### PR DESCRIPTION
- Closes https://github.com/pixiebrix/webext-messenger/issues/131

Before going forward with testing:

- is `attempts-exhausted` actually useful or could the regular `retry (9)` be enough to determine it was eventually discarded?
- are these the two events you're looking for? Do their names make sense?
- the event includes the `message type`, `target`, `error` and `attemptCount`
	- Including the actual message requires a bit of passing around, so I'll only include it if you think it would be useful (or we can add it later)
	- the sequence number will also be included after its PR is merged: #133 
- we could also have `log.debug()` and `log.warn()` dispatch their own events, but I'm not sure you would find them useful