### PR TITLE
Move logging toggle to a safer location

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,13 @@
   "license": "MIT",
   "author": "Federico Brigante for PixieBrix <federico@pixiebrix.com> (https://www.pixiebrix.com)",
   "type": "module",
-  "main": "distribution/index.js",
+  "exports": {
+    ".": {
+      "types": "./distribution/index.js",
+      "default": "./distribution/index.js"
+    },
+    "./*": "./distribution/*"
+  },
   "scripts": {
     "build": "tsc",
     "demo:watch": "parcel watch --no-cache --no-hmr",

--- a/source/index.ts
+++ b/source/index.ts
@@ -4,7 +4,7 @@ export * from "./receiver.js";
 export * from "./sender.js";
 export * from "./types.js";
 export { getThisFrame, getTopLevelFrame } from "./thisTarget.js";
-export { toggleLogging } from "./shared.js";
+export { toggleLogging } from "./logging.js";
 
 import { initPrivateApi } from "./thisTarget.js";
 

--- a/source/logging.ts
+++ b/source/logging.ts
@@ -1,0 +1,17 @@
+/* Warning: Do not use import browser-polyfill directly or indirectly */
+
+// .bind preserves the call location in the console
+const debug = console.debug.bind(console, "Messenger:");
+const warn = console.warn.bind(console, "Messenger:");
+
+const noop: (...args: unknown[]) => void = () => {
+  /* */
+};
+
+// Default to "no logs"
+export const log = { debug: noop, warn: noop };
+
+export function toggleLogging(enabled: boolean): void {
+  log.debug = enabled ? debug : noop;
+  log.warn = enabled ? warn : noop;
+}

--- a/source/receiver.ts
+++ b/source/receiver.ts
@@ -8,7 +8,8 @@ import {
   type Method,
   type Sender,
 } from "./types.js";
-import { isObject, MessengerError, log, __webextMessenger } from "./shared.js";
+import { isObject, MessengerError, __webextMessenger } from "./shared.js";
+import { log } from "./logging.js";
 import { getActionForMessage } from "./thisTarget.js";
 import { didUserRegisterMethods, handlers } from "./handlers.js";
 

--- a/source/sender.ts
+++ b/source/sender.ts
@@ -12,7 +12,8 @@ import {
   type PageTarget,
   type AnyTarget,
 } from "./types.js";
-import { isObject, MessengerError, __webextMessenger, log } from "./shared.js";
+import { isObject, MessengerError, __webextMessenger } from "./shared.js";
+import { log } from "./logging.js";
 import { type SetReturnType } from "type-fest";
 import { handlers } from "./handlers.js";
 

--- a/source/shared.ts
+++ b/source/shared.ts
@@ -13,30 +13,12 @@ export function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function noop() {
-  /* */
-}
-
 export class MessengerError extends Error {
   override name = "MessengerError";
 }
 
 // @ts-expect-error Wrong `errorConstructors` types
 errorConstructors.set("MessengerError", MessengerError);
-
-// .bind preserves the call location in the console
-const debug = console.debug.bind(console, "Messenger:");
-const warn = console.warn.bind(console, "Messenger:");
-
-export const log = { debug, warn };
-
-export function toggleLogging(enabled: boolean): void {
-  log.debug = enabled ? debug : noop;
-  log.warn = enabled ? warn : noop;
-}
-
-// Default to "no logs"
-toggleLogging(false);
 
 export function isErrorObject(error: unknown): error is ErrorObject {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- This is a type guard function and it uses ?.

--- a/source/thisTarget.ts
+++ b/source/thisTarget.ts
@@ -14,7 +14,8 @@ import {
   type Sender,
   type FrameTarget,
 } from "./types.js";
-import { log, MessengerError, once } from "./shared.js";
+import { MessengerError, once } from "./shared.js";
+import { log } from "./logging.js";
 import { type Entries } from "type-fest";
 
 /**
@@ -152,7 +153,7 @@ export function __getTabData(this: MessengerMeta): AnyTarget {
 }
 
 export async function getThisFrame(): Promise<FrameTarget> {
-  await storeTabData(); // It should already have been called by we still need to await it
+  await storeTabData(); // It should already have been called but we still need to await it
 
   const { tabId, frameId } = thisTarget;
 


### PR DESCRIPTION
This will reduce the chance of importing `webextension-polyfill` by mistake. See [pixiebrix/pixiebrix-extension@`9664382` (#6702)](https://github.com/pixiebrix/pixiebrix-extension/pull/6702/commits/9664382417ba86928cb61fc64dfe754a897000be)


```diff
- import { toggleLogging } from "webext-messenger"; // Imports everything
+ import { toggleLogging } from "webext-messenger/shared.js"; // Imports just the toggle, if it's used
```