### PR TITLE
Support `Promise<Target>` in methods with static targets

### DIFF
--- a/source/test/contentscript/api.test.ts
+++ b/source/test/contentscript/api.test.ts
@@ -1,7 +1,11 @@
 import test from "tape";
 import { isBackground, isContentScript, isWebPage } from "webext-detect-page";
 import { type PageTarget, type Sender, type Target } from "../../index.js";
-import { errorTabDoesntExist, errorTargetClosedEarly } from "../../sender.js";
+import {
+  errorTabDoesntExist,
+  errorTargetClosedEarly,
+  getMethod,
+} from "../../sender.js";
 import {
   expectRejection,
   sleep,
@@ -392,6 +396,18 @@ function additionalTests() {
     );
     getPageTitleNotification({ tabId });
     await closeTab(tabId);
+  });
+
+  test("should support target promises in methods with static targets", async (t) => {
+    const tabIdPromise = openTab(
+      "https://fregante.github.io/pixiebrix-testing-ground/Will-receive-CS-calls/Promised-target"
+    );
+    const targetPromise = tabIdPromise.then((tabId) => ({ tabId }));
+
+    const request = getMethod("getPageTitle", targetPromise);
+    t.equal(await request(), "Promised target");
+
+    await closeTab(await tabIdPromise);
   });
 }
 


### PR DESCRIPTION
I almost closed this one but it turns out it wasn't too difficult. Just took like an hour including testing:

- Closes https://github.com/pixiebrix/webext-messenger/issues/193
- For https://github.com/pixiebrix/pixiebrix-extension/pull/7354

### Difficult parts

- accepting a promised target in `getNotifier` without making it a `async`
- deciding to not accept target promises in non-static methods
	- in `getMethod('ABC', target)('arg')` the target can be a promise
	- in `getMethod('ABC')(target, 'arg')` the target must not be a promise
		- this is because the caller can just use `await target` in place, without losing any type information like in methods with static targets

### Why

To avoid either one of these two solutions:

- https://github.com/pixiebrix/pixiebrix-extension/blob/6ff08d03e710738fc6a6d8b8f38e1099fb4f9cc0/src/sidebar/messenger/api.ts#L28-L60
- https://github.com/pixiebrix/pixiebrix-extension/blob/ad8b8412a89c04e1998e50e83953a2406b104ba6/src/sidebar/messenger/api.ts#L24-L34