### PR TITLE
Allow skipping retries (only via main `messenger` function)

### DIFF
--- a/source/sender.ts
+++ b/source/sender.ts
@@ -56,12 +56,12 @@ function makeMessage(
 // Do not turn this into an `async` function; Notifications must turn `void`
 function manageConnection(
   type: string,
-  { seq, isNotification }: Options,
+  { seq, isNotification, retry }: Options,
   target: AnyTarget,
   sendMessage: (attempt: number) => Promise<unknown>
 ): Promise<unknown> | void {
   if (!isNotification) {
-    return manageMessage(type, target, seq!, sendMessage);
+    return manageMessage(type, target, seq!, retry ?? true, sendMessage);
   }
 
   void sendMessage(1).catch((error: unknown) => {
@@ -73,8 +73,10 @@ async function manageMessage(
   type: string,
   target: AnyTarget,
   seq: number,
+  retry: boolean,
   sendMessage: (attempt: number) => Promise<unknown>
 ): Promise<unknown> {
+  // TODO: Split this up a bit because it's too long. Probably drop p-retry
   const response = await pRetry(
     async (attemptCount) => {
       const response = await sendMessage(attemptCount);
@@ -115,6 +117,8 @@ async function manageMessage(
     {
       minTimeout: 100,
       factor: 1.3,
+      // Do not set this to undefined or Infinity, it doesn't work the same way
+      ...(retry ? {} : { retries: 0 }),
       maxRetryTime: 4000,
       async onFailedAttempt(error) {
         events.dispatchEvent(

--- a/source/test/contentscript/api.test.ts
+++ b/source/test/contentscript/api.test.ts
@@ -5,6 +5,7 @@ import {
   errorTabDoesntExist,
   errorTargetClosedEarly,
   getMethod,
+  messenger,
 } from "../../sender.js";
 import {
   expectRejection,
@@ -319,6 +320,27 @@ function additionalTests() {
     );
 
     expectDuration(t, await durationPromise, 4000, 5000);
+
+    await closeTab(tabId);
+  });
+
+  test("does not retry if specifically asked not to", async (t) => {
+    const tabId = await openTab(
+      "https://fregante.github.io/pixiebrix-testing-ground/No-static-content-scripts"
+    );
+
+    const request = messenger("getPageTitle", { retry: false }, { tabId });
+    const durationPromise = trackSettleTime(request);
+
+    await expectRejection(
+      t,
+      request,
+      new MessengerError(
+        `The target ${JSON.stringify({ tabId })} for getPageTitle was not found`
+      )
+    );
+
+    expectDuration(t, await durationPromise, 0);
 
     await closeTab(tabId);
   });

--- a/source/types.ts
+++ b/source/types.ts
@@ -68,6 +68,7 @@ export interface Options {
    */
   isNotification?: boolean;
   trace?: Sender[];
+  retry?: boolean;
 
   /** Automatically generated internally */
   seq?: number;


### PR DESCRIPTION
The options are only exposed via `messenger`, not `getMethod`/`getNotifier`, because they _set_ some options themselves. This is because of complexities in partial function application.

This is not ideal, but we haven't needed this until now so it won't be needed often.

- Closes https://github.com/pixiebrix/webext-messenger/issues/59

Replaces:  https://github.com/pixiebrix/pixiebrix-extension/blob/53ad10d34994f209864f5f30f6854c7292fd3769/src/sidebar/sidePanel.tsx#L30-L42

### Demo

```js
import { messenger } from "webext-messenger";

try {
	await messenger("PING", { retry: false }, { tabId: 1234 });
	console.log('got ponged')
} catch {
	console.warn('ping failed immediately')
}
```