### PR TITLE
Run tests in the background

### DIFF
--- a/source/test/background/testingApi.ts
+++ b/source/test/background/testingApi.ts
@@ -1,4 +1,5 @@
 import { executeFunction } from "webext-content-scripts";
+import { once } from "../../shared.js";
 
 export async function ensureScripts(tabId: number): Promise<void> {
   await browser.tabs.executeScript(tabId, {
@@ -56,12 +57,25 @@ export async function createTargets(): Promise<Targets> {
   throw new Error("The expected frames were not found");
 }
 
+const getHiddenWindow = once(async (): Promise<number> => {
+  const { id } = await browser.windows.create({
+    focused: false,
+    state: "minimized",
+  });
+  return id!;
+});
+
 export async function openTab(url: string): Promise<number> {
   const tab = await browser.tabs.create({
+    windowId: await getHiddenWindow(),
     active: false,
     url,
   });
   return tab.id!;
+}
+
+export async function closeHiddenWindow(): Promise<void> {
+  return browser.windows.remove(await getHiddenWindow());
 }
 
 export async function closeTab(tabId: number): Promise<void> {


### PR DESCRIPTION
The live-test extension is very confusing because tabs are opened and closed continuously while the tests run.

This change will move those tab opening/closing into a minimized window.

To recap:

- `web-ext run` opens two tabs and the background context:
	- a content script runner that messages the background
	- a content script runner that creates tabs and messages them via the background
	- a background runner that that creates tabs and messages them 
- additionally, you can manually open the options page and will run the same tests as the background page
 