### PR TITLE
Update test extension documentation

### DIFF
--- a/source/test/readme.md
+++ b/source/test/readme.md
@@ -7,6 +7,6 @@ npm run demo:watch
 npx web-ext run --target=chromium
 ```
 
-You should see the changes applied by both `static.*` and `dynamic.*` files, respectively files loaded via manifest and via the `.register` API.
+Several tabs will automatically open, this is the various contexts running tests. You can open the console of the 2 main tabs, the background console and other contexts' consoles to see the results of each test.
 
-Also open the background script console to see any errors.
+The `registration.ts` files are APIs for that specific context and can be called/tested from any other context. For example the background loads both `background/registration.ts` (to receive calls) and `contentscript/api.test.ts` (to start testing the content script API).


### PR DESCRIPTION
I saw that the docs were copy-pasted from a different project. This adds a bit of context.

The test extension currently includes the targets:

- background to content script
- options to background
- content script to background
- content script to content script (via background) 

It might be a good time to add:

- sidePanel
- offscreen
	- after #273 
