### PR TITLE
Drop webextension-polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@sindresorhus/tsconfig": "^7.0.0",
         "@types/chrome": "^0.0.307",
         "@types/tape": "^5.8.1",
-        "@types/webextension-polyfill": "^0.12.2",
         "buffer": "^6.0.3",
         "eslint": "^8.57.0",
         "eslint-config-pixiebrix": "^0.41.1",
@@ -34,8 +33,7 @@
         "tape": "^5.9.0",
         "typescript": "^5.8.2",
         "vitest": "^3.0.7",
-        "webext-content-scripts": "^2.7.2",
-        "webextension-polyfill": "^0.12.0"
+        "webext-content-scripts": "^2.7.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -13771,13 +13769,6 @@
         "mock-property": "*"
       }
     },
-    "node_modules/@types/webextension-polyfill": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@types/webextension-polyfill/-/webextension-polyfill-0.12.2.tgz",
-      "integrity": "sha512-rUIyZfbj1TcxlV0IWyy7MUHnW24nqUfQR0F+vPru/3t4noA9Pd4sdG4sljQgQHLd1vYgmkFLSvEc/furzQPbUw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
@@ -21661,12 +21652,6 @@
       "funding": {
         "url": "https://github.com/sponsors/fregante"
       }
-    },
-    "node_modules/webextension-polyfill": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.12.0.tgz",
-      "integrity": "sha512-97TBmpoWJEE+3nFBQ4VocyCdLKfw54rFaJ6EVQYLBCXqCIpLSZkwGgASpv4oPt9gdKCJ80RJlcmNzNn008Ag6Q==",
-      "dev": true
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@sindresorhus/tsconfig": "^7.0.0",
     "@types/chrome": "^0.0.307",
     "@types/tape": "^5.8.1",
-    "@types/webextension-polyfill": "^0.12.2",
     "buffer": "^6.0.3",
     "eslint": "^8.57.0",
     "eslint-config-pixiebrix": "^0.41.1",
@@ -54,8 +53,7 @@
     "tape": "^5.9.0",
     "typescript": "^5.8.2",
     "vitest": "^3.0.7",
-    "webext-content-scripts": "^2.7.2",
-    "webextension-polyfill": "^0.12.0"
+    "webext-content-scripts": "^2.7.2"
   },
   "targets": {
     "main": false,

--- a/source/logging.ts
+++ b/source/logging.ts
@@ -1,5 +1,3 @@
-/* Warning: Do not use import browser-polyfill directly or indirectly */
-
 // .bind preserves the call location in the console
 const debug = console.debug.bind(console, "Messenger:");
 const warn = console.warn.bind(console, "Messenger:");

--- a/source/receiver.ts
+++ b/source/receiver.ts
@@ -52,6 +52,8 @@ function onMessageListener(
     }
   })();
 
+  // Make `sendMessage` wait for an async response. This stops other `onMessage` listeners from being called.
+  // TODO: Just return a promise if this is ever implemented https://issues.chromium.org/issues/40753031
   return true;
 }
 

--- a/source/sender.ts
+++ b/source/sender.ts
@@ -1,4 +1,3 @@
-import browser from "webextension-polyfill";
 import pRetry from "p-retry";
 import { isBackground } from "webext-detect";
 import { deserializeError } from "serialize-error";
@@ -166,9 +165,9 @@ async function manageMessage(
           throw error;
         }
 
-        if (browser.tabs && typeof target.tabId === "number") {
+        if (chrome.tabs && typeof target.tabId === "number") {
           try {
-            const tabInfo = await browser.tabs.get(target.tabId);
+            const tabInfo = await chrome.tabs.get(target.tabId);
             if (tabInfo.discarded) {
               throw new Error(errorTabWasDiscarded);
             }
@@ -270,7 +269,7 @@ function messenger<
         "↗️ sending message to runtime",
         attemptLog(attemptCount),
       );
-      return browser.runtime.sendMessage(
+      return chrome.runtime.sendMessage(
         makeMessage(type, args, target, options),
       );
     };
@@ -279,7 +278,7 @@ function messenger<
   }
 
   // Contexts without direct Tab access must go through background
-  if (!browser.tabs) {
+  if (!chrome.tabs) {
     return manageConnection(
       type,
       options,
@@ -291,7 +290,7 @@ function messenger<
           "↗️ sending message to runtime",
           attemptLog(attemptCount),
         );
-        return browser.runtime.sendMessage(
+        return chrome.runtime.sendMessage(
           makeMessage(type, args, target, options),
         );
       },
@@ -316,7 +315,7 @@ function messenger<
         frameId,
         attemptLog(attemptCount),
       );
-      return browser.tabs.sendMessage(
+      return chrome.tabs.sendMessage(
         tabId,
         makeMessage(type, args, target, options),
         frameId === "allFrames"

--- a/source/sender.ts
+++ b/source/sender.ts
@@ -21,7 +21,6 @@ import { events } from "./events.js";
 const _errorNonExistingTarget =
   "Could not establish connection. Receiving end does not exist.";
 
-// https://github.com/mozilla/webextension-polyfill/issues/384
 const _errorTargetClosedEarly =
   "A listener indicated an asynchronous response by returning true, but the message channel closed before a response was received";
 

--- a/source/targetLogic.test.ts
+++ b/source/targetLogic.test.ts
@@ -1,6 +1,5 @@
 import { assert, describe, test, vi } from "vitest";
 import { getActionForMessage } from "./targetLogic.js";
-import { type Tabs } from "webextension-polyfill";
 import { isContentScript, isBackground } from "webext-detect";
 
 vi.mock("webext-detect");
@@ -14,7 +13,12 @@ const tab = {
   pinned: false,
   highlighted: true,
   incognito: false,
-} satisfies Tabs.Tab;
+  discarded: false,
+  frozen: false,
+  selected: true,
+  autoDiscardable: false,
+  groupId: -1,
+} satisfies chrome.tabs.Tab;
 
 const senders = {
   background: { page: "background" },

--- a/source/test/background/testingApi.ts
+++ b/source/test/background/testingApi.ts
@@ -1,9 +1,8 @@
-import browser from "webextension-polyfill";
 import { executeFunction } from "webext-content-scripts";
 import { once } from "webext-messenger/shared.js";
 
 export async function ensureScripts(tabId: number): Promise<void> {
-  await browser.scripting.executeScript({
+  await chrome.scripting.executeScript({
     target: { tabId },
     files: ["contentscript/registration.js"],
   });
@@ -31,7 +30,7 @@ export async function createTargets(): Promise<Targets> {
   let frames;
   while (limit--) {
     // eslint-disable-next-line no-await-in-loop -- It's a retry loop
-    frames = (await browser.webNavigation.getAllFrames({
+    frames = (await chrome.webNavigation.getAllFrames({
       tabId,
     }))!;
 
@@ -57,7 +56,7 @@ export async function createTargets(): Promise<Targets> {
 }
 
 const getHiddenWindow = once(async (): Promise<number> => {
-  const { id } = await browser.windows.create({
+  const { id } = await chrome.windows.create({
     focused: false,
     state: "minimized",
   });
@@ -65,7 +64,7 @@ const getHiddenWindow = once(async (): Promise<number> => {
 });
 
 export async function openTab(url: string): Promise<number> {
-  const tab = await browser.tabs.create({
+  const tab = await chrome.tabs.create({
     windowId: await getHiddenWindow(),
     active: false,
     url,
@@ -74,9 +73,9 @@ export async function openTab(url: string): Promise<number> {
 }
 
 export async function closeHiddenWindow(): Promise<void> {
-  return browser.windows.remove(await getHiddenWindow());
+  return chrome.windows.remove(await getHiddenWindow());
 }
 
 export async function closeTab(tabId: number): Promise<void> {
-  await browser.tabs.remove(tabId);
+  await chrome.tabs.remove(tabId);
 }

--- a/source/test/contentscript/api.test.ts
+++ b/source/test/contentscript/api.test.ts
@@ -1,4 +1,3 @@
-import browser from "webextension-polyfill";
 import test from "tape";
 import { isBackground, isContentScript, isWebPage } from "webext-detect";
 import { type PageTarget, type Target } from "webext-messenger";
@@ -184,7 +183,7 @@ async function testEveryTarget() {
     await closeSelf({ tabId, frameId: parentFrame });
     try {
       // Since the tab was closed, this is expected to throw
-      t.notOk(await browser.tabs.get(tabId), "The tab should not be open");
+      t.notOk(await chrome.tabs.get(tabId), "The tab should not be open");
     } catch {
       t.pass("The tab was closed");
     }

--- a/source/test/contentscript/fixtures/unrelatedMessageListener.ts
+++ b/source/test/contentscript/fixtures/unrelatedMessageListener.ts
@@ -1,14 +1,15 @@
-import browser from "webextension-polyfill";
-
-browser.runtime.onMessage.addListener(
-  (message: unknown): Promise<string> | undefined => {
+chrome.runtime.onMessage.addListener(
+  (message: unknown, _sender, sendResponse): boolean | undefined => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if ((message as any)?.type === "sleep") {
       console.log(
         "I’m an unrelated message listener, but I'm replying anyway to",
         { message },
       );
-      return Promise.resolve("/r/nosleep");
+
+      void Promise.resolve("User is on Windows 95").then(sendResponse);
+
+      return true;
     }
 
     console.log("I’m an unrelated message listener. I’ve seen", { message });

--- a/source/test/contentscript/fixtures/unrelatedMessageListener.ts
+++ b/source/test/contentscript/fixtures/unrelatedMessageListener.ts
@@ -7,7 +7,7 @@ chrome.runtime.onMessage.addListener(
         { message },
       );
 
-      void Promise.resolve("User is on Windows 95").then(sendResponse);
+      void Promise.resolve("Buonanotte").then(sendResponse);
 
       return true;
     }

--- a/source/types.ts
+++ b/source/types.ts
@@ -1,4 +1,3 @@
-import { type Runtime } from "webextension-polyfill";
 import { type Asyncify, type ValueOf } from "type-fest";
 import { type ErrorObject } from "serialize-error";
 
@@ -83,7 +82,7 @@ export type Message<LocalArguments extends Arguments = Arguments> = {
   options?: Options;
 };
 
-export type Sender = Runtime.MessageSender & { origin?: string }; // Chrome includes the origin
+export type Sender = chrome.runtime.MessageSender;
 
 export type MessengerMessage = Message & {
   /** Guarantees that a message is meant to be handled by this library */


### PR DESCRIPTION
- Closes #126 
- Closes https://github.com/pixiebrix/webext-messenger/issues/67
	- Dropping the polyfill means removing the regression risk. More context in the issue
- Replaces https://github.com/pixiebrix/webext-messenger/pull/19
- Replaces https://github.com/pixiebrix/webext-messenger/pull/123
- Unblocks https://github.com/pixiebrix/webext-messenger/issues/6
	- which unblocks https://github.com/pixiebrix/pixiebrix-source/issues/791


All tests pass except a pre-existing bug:

- #211 

This PR was suspiciously easy to implement 