### PR TITLE
Replace `p-event` with `one-event`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.33.2",
       "license": "MIT",
       "dependencies": {
-        "p-event": "^7.0.0",
+        "one-event": "^4.3.0",
         "p-retry": "^6.2.1",
         "serialize-error": "^12.0.0",
         "type-fest": "^5.0.1",
@@ -8852,6 +8852,18 @@
         "wrappy": "1"
       }
     },
+    "node_modules/one-event": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/one-event/-/one-event-4.3.0.tgz",
+      "integrity": "sha512-R6RkjfeEieV6+fz2JDuRD1KwP2qXLg0Y3/33RgvaAE5+TiqKaE7l+2qOHmHMMoRwa8qnN6FDPS9D/wNT40+OeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fregante"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -8875,21 +8887,6 @@
       "integrity": "sha512-IQh2aMfMIDbPjI/8a3Edr+PiOpcsB7yo8NdW7aHWVaoR/pcDldunMvnnwbk/auPGqmKeAdxtZl7MHX/QmPwhvQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/p-event": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/p-event/-/p-event-7.0.0.tgz",
-      "integrity": "sha512-z4Xv/ieHhi6Dx3A5xbZI8WWTn+eSRo6buGTvA8Yv2iLyX+61SUIMKcBszZRHA6e2Apld6QEDSclAuha2iUntyA==",
-      "license": "MIT",
-      "dependencies": {
-        "p-timeout": "^6.1.4"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -8933,18 +8930,6 @@
       },
       "engines": {
         "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
-      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "watch": "tsc --watch"
   },
   "dependencies": {
-    "p-event": "^7.0.0",
+    "one-event": "^4.3.0",
     "p-retry": "^6.2.1",
     "serialize-error": "^12.0.0",
     "type-fest": "^5.0.1",

--- a/source/thisTarget.ts
+++ b/source/thisTarget.ts
@@ -14,7 +14,7 @@ import {
   type FrameTarget,
 } from "./types.js";
 import { MessengerError, once } from "./shared.js";
-import { pEvent } from "p-event";
+import oneEvent from "one-event";
 
 /**
  * @file This file exists because `runtime.sendMessage` acts as a broadcast to
@@ -72,7 +72,7 @@ const storeTabData = once(async () => {
   // If the page is prerendering, wait for the change to be able to get the tab data so the frameId is correct
   // https://developer.mozilla.org/en-US/docs/Web/API/Document/prerenderingchange_event
   if ("prerendering" in document && Boolean(document.prerendering)) {
-    await pEvent(document, "prerenderingchange");
+    await oneEvent(document, "prerenderingchange");
   }
 
   try {


### PR DESCRIPTION
`p-event` depends on an old version of `p-timeout`, which we just bumped in the monorepo.

`one-event` is tiny (mine) and is already used in the monorepo.