### PR TITLE
Grant contents: write so the release workflow can push tags

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,7 +17,7 @@ on:
 
 permissions:
   id-token: write # Required for OIDC
-  contents: read
+  contents: write # Required to push the version tag and create the release
 
 jobs:
   NPM:


### PR DESCRIPTION
## Problem

After #417 fixed npm trusted publishing, the Publish workflow got further but failed at `git push --follow-tags`:

```
remote: Permission to pixiebrix/webext-messenger.git denied to github-actions[bot].
fatal: ... The requested URL returned error: 403
```

The workflow's `GITHUB_TOKEN` only had `contents: read`, but pushing the version tag and running `gh release create` both require `contents: write`. ([failed run](https://github.com/pixiebrix/webext-messenger/actions/runs/29126439472/job/86472938323))

## Fix

Change the workflow permission from `contents: read` to `contents: write`. `id-token: write` is retained for OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)