### PR TITLE
Bump typescript from 5.9.3 to 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "process": "^0.11.10",
         "stream-browserify": "^3.0.0",
         "tape": "^5.10.2",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.10"
       }
     },
@@ -3519,12 +3519,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "24.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.8.tgz",
-      "integrity": "sha512-WytNrFSgWO/esSH9NbpWUfTMGQwCGIKfCmNlmFDNiI5gGhgMmEA+V1AEvKLeBNvvtBnailJtkrEa2OIISwrVAA==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -10675,9 +10676,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -10708,10 +10709,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "dev": true
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "process": "^0.11.10",
     "stream-browserify": "^3.0.0",
     "tape": "^5.10.2",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.10"
   },
   "targets": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,14 @@
   "include": ["source/**/*"],
   "compilerOptions": {
     "esModuleInterop": true,
-    "baseUrl": ".",
+    "rootDir": "./source",
     "outDir": "distribution",
     "skipLibCheck": false,
+    // TypeScript 6 no longer auto-includes every node_modules/@types package
+    "types": ["chrome"],
     "paths": {
-      "webext-messenger/*": ["source/*"],
-      "webext-messenger": ["source/index.ts"]
+      "webext-messenger/*": ["./source/*"],
+      "webext-messenger": ["./source/index.ts"]
     }
   }
 }


### PR DESCRIPTION
Supersedes #424, which bumped straight to TypeScript 7.0.2.

## Why not 7.0.2

TS 7 is the native Go compiler and does not yet expose a public compiler API, so nothing that does `require("typescript")` works against it. `npm run lint` crashes in `ts-api-utils`:

```
TypeError: Failed to load plugin '@typescript-eslint': Cannot read properties of undefined (reading 'Intrinsic')
```

This is blocked upstream, not a config problem — `typescript-eslint@8.65.0` and its canary both declare `typescript: >=4.8.4 <6.1.0`, and `ts-api-utils@3.0.0-rc.1` declares `<7`. typescript-eslint/typescript-eslint#12518 was closed as *not planned*, pointing at typescript-eslint/typescript-eslint#10940 as the tracker.

TypeScript 6 is the last JS-based compiler and sits inside that peer range, so it gets the config migration done under deprecation errors instead of hard removals. The eventual 7.x bump becomes a one-line change once typescript-eslint lands support.

## tsconfig changes

TS 6 turns several options into deprecation errors and drops automatic `@types` inclusion:

- **`baseUrl` → `rootDir`** — `baseUrl` is deprecated and removed in 7.0 (`TS5101`/`TS5102`); with it gone, `rootDir` must be explicit (`TS5011`)
- **`paths` values made relative** — non-relative values are rejected in 7.0 (`TS5090`)
- **`types: ["chrome"]`** — 5.9 auto-included all 13 packages under `node_modules/@types`; 6.0 includes only import-reachable ones, which dropped the `chrome` globals and produced ~35 `TS2304 Cannot find name 'chrome'`

## @types/node

Refreshed 24.0.8 → 26.1.2 in the lockfile. 24.0.8 declares `URLPattern` incompatibly with TS 6's `lib.dom.d.ts`, which this project sees because it sets `skipLibCheck: false`. `@types/tape` already requests `@types/node: "*"`, so this is a lockfile refresh with no new direct dependency.

## Verification

`npm test` (unit + lint + build + demo:build) passes locally, and the emitted `distribution/` is **byte-identical to the 5.9.3 output across all 106 files** — the published API is unchanged.
